### PR TITLE
Fix syntax highlighter typo in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ## [Unreleased]
 ### Changed
-- Initial Parser language 
-- Initial Lexer Adapter 
-- Initial Syntax High Lither
+- Initial Parser language
+- Initial Lexer Adapter
+- Initial Syntax Highlighter
 ### Fixed
-- Build properties 
+- Build properties
 - Language definitions
 ### Changed
 - Upgrade Gradle version


### PR DESCRIPTION
## Summary
- fix typo `Initial Syntax High Lither` to `Initial Syntax Highlighter`

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 63)*

------
https://chatgpt.com/codex/tasks/task_e_68a736c23dd883229f01626cec59c93e