### PR TITLE
Validate inputs in NOX3ElementFactory

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,10 @@ repositories {
     mavenCentral()
 }
 
+dependencies {
+    testImplementation(kotlin("test"))
+}
+
 // Bloco Kotlin agora usa jvmToolchain para garantir que o JDK 17 seja usado.
 // Isso corrige o erro de compilação original.
 kotlin {

--- a/src/main/kotlin/com/enterscript/noX3LanguagePlugin/language/psi/impl/NOX3ElementFactory.kt
+++ b/src/main/kotlin/com/enterscript/noX3LanguagePlugin/language/psi/impl/NOX3ElementFactory.kt
@@ -11,12 +11,14 @@ class NOX3ElementFactory {
     companion object {
 
         private fun createFile(project: Project?, text: String?): NOX3File {
+            val content = text ?: throw IllegalArgumentException("text cannot be null")
             val name = "SPEDUMMY.src"
-            return PsiFileFactory.getInstance(project).createFileFromText(name, NOX3FileType.INSTANCE, text.toString()) as NOX3File
+            return PsiFileFactory.getInstance(project).createFileFromText(name, NOX3FileType.INSTANCE, content) as NOX3File
         }
 
         fun createProperty(project: Project?, name: String?): NOX3Property {
-            val file: NOX3File = createFile(project, name)
+            val propertyName = name ?: throw IllegalArgumentException("name cannot be null")
+            val file: NOX3File = createFile(project, propertyName)
             return file.firstChild as NOX3Property
         }
 

--- a/src/main/kotlin/com/enterscript/noX3LanguagePlugin/language/psi/impl/NOX3PsiImplUtil.kt
+++ b/src/main/kotlin/com/enterscript/noX3LanguagePlugin/language/psi/impl/NOX3PsiImplUtil.kt
@@ -31,7 +31,8 @@ class NOX3PsiImplUtil{
         fun setName(element: NOX3Property, newName: String?): PsiElement? {
             val keyNode: ASTNode? = element.node.findChildByType(NOX3Types.KEY)
             if (keyNode != null) {
-                val property: NOX3Property = NOX3ElementFactory.createProperty(element.project, newName)
+                val name = newName ?: throw IllegalArgumentException("name cannot be null")
+                val property: NOX3Property = NOX3ElementFactory.createProperty(element.project, name)
                 val newKeyNode: ASTNode = property.firstChild.node
                 element.node.replaceChild(keyNode, newKeyNode)
             }

--- a/src/test/kotlin/com/enterscript/noX3LanguagePlugin/language/psi/impl/NOX3ElementFactoryTest.kt
+++ b/src/test/kotlin/com/enterscript/noX3LanguagePlugin/language/psi/impl/NOX3ElementFactoryTest.kt
@@ -1,0 +1,21 @@
+package com.enterscript.noX3LanguagePlugin.language.psi.impl
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+
+class NOX3ElementFactoryTest : BasePlatformTestCase() {
+
+    fun testCreatePropertyValid() {
+        val property = NOX3ElementFactory.createProperty(project, "foo")
+        assertNotNull(property)
+        assertEquals("foo", property.key)
+    }
+
+    fun testCreatePropertyNullNameThrows() {
+        assertFailsWith<IllegalArgumentException> {
+            NOX3ElementFactory.createProperty(project, null)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Guard against null text/name in NOX3ElementFactory
- Enforce non-null property names in NOX3PsiImplUtil
- Add tests for property creation and null handling

## Testing
- `./gradlew test --stacktrace` *(fails: Unsupported class file major version 63)*

------
https://chatgpt.com/codex/tasks/task_e_68a73c4bf0a48322ae6c3187b6502b1a