### PR TITLE
feat: validate function call references

### DIFF
--- a/src/main/kotlin/com/enterscript/noX3LanguagePlugin/language/NOX3FunctionCallInspection.kt
+++ b/src/main/kotlin/com/enterscript/noX3LanguagePlugin/language/NOX3FunctionCallInspection.kt
@@ -1,0 +1,33 @@
+package com.enterscript.noX3LanguagePlugin.language
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.JavaElementVisitor
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiLiteralExpression
+
+/**
+ * Inspection that validates NOX3 function calls inside string literals.
+ * It relies on [NOX3ReferenceContributor] to resolve function names and
+ * reports unresolved or ambiguous references.
+ */
+class NOX3FunctionCallInspection : LocalInspectionTool() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object : JavaElementVisitor() {
+            override fun visitLiteralExpression(expression: PsiLiteralExpression) {
+                val value = expression.value as? String ?: return
+                val prefix = NOX3Annotator.NOX3_PREFIX_STR + NOX3Annotator.NOX3_SEPARATOR_STR
+                if (!value.startsWith(prefix)) return
+
+                val references = expression.references.filterIsInstance<NOX3Reference>()
+                if (references.isEmpty()) return
+
+                val results = references.flatMap { it.multiResolve(false).toList() }
+                when {
+                    results.isEmpty() -> holder.registerProblem(expression, "Unresolved function call")
+                    results.size > 1 -> holder.registerProblem(expression, "Ambiguous function call")
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -47,6 +47,13 @@
         <codeInsight.lineMarkerProvider
                 language="JAVA"
                 implementationClass="com.enterscript.noX3LanguagePlugin.language.NOX3LineMarkerProvider"/>
+        <localInspection
+                language="JAVA"
+                shortName="NOX3FunctionCall"
+                displayName="NOX3 function call validator"
+                groupName="NOX3"
+                enabledByDefault="true"
+                implementationClass="com.enterscript.noX3LanguagePlugin.language.NOX3FunctionCallInspection"/>
     </extensions>
 
     <applicationListeners>

--- a/src/test/kotlin/com/enterscript/noX3LanguagePlugin/language/NOX3FunctionCallInspectionTest.kt
+++ b/src/test/kotlin/com/enterscript/noX3LanguagePlugin/language/NOX3FunctionCallInspectionTest.kt
@@ -1,0 +1,26 @@
+package com.enterscript.noX3LanguagePlugin.language
+
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixture4TestCase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class NOX3FunctionCallInspectionTest : LightJavaCodeInsightFixture4TestCase() {
+
+    @Test
+    fun testValidFunctionCall() {
+        myFixture.configureByText("a.src", "foo=bar")
+        myFixture.configureByText("Foo.java", "class Foo { String a = \"X3:foo\"; }")
+        myFixture.enableInspections(NOX3FunctionCallInspection())
+        val highlights = myFixture.doHighlighting()
+        assertEquals(0, highlights.count { it.severity.myName == "ERROR" })
+    }
+
+    @Test
+    fun testInvalidFunctionCall() {
+        myFixture.configureByText("Foo.java", "class Foo { String a = \"X3:missing\"; }")
+        myFixture.enableInspections(NOX3FunctionCallInspection())
+        val highlights = myFixture.doHighlighting()
+        assertTrue(highlights.any { it.description?.contains("Unresolved function call") == true })
+    }
+}


### PR DESCRIPTION
## Summary
- add inspection to validate NOX3 function call strings against declarations
- register inspection in plugin descriptor
- cover valid and invalid references with tests

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 63)*
- `./gradlew compileKotlin` *(fails: Unsupported class file major version 63)*

------
https://chatgpt.com/codex/tasks/task_e_68a76a6774ec8322a8fbc8dec1a9b0a9