### PR TITLE
Add menu action to create X3 package structure

### DIFF
--- a/src/main/kotlin/com/enterscript/noX3LanguagePlugin/MenuAction.kt
+++ b/src/main/kotlin/com/enterscript/noX3LanguagePlugin/MenuAction.kt
@@ -2,15 +2,30 @@ package com.enterscript.noX3LanguagePlugin
 
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.ui.Messages
+import com.intellij.openapi.vfs.VfsUtil
 
-
+/**
+ * Action that creates the X3 language package structure.
+ */
 class MenuAction : AnAction() {
-    // menu creation reference https://www.youtube.com/watch?v=IeqRswA9VP8
-    //12m00s
     override fun actionPerformed(e: AnActionEvent) {
-        Messages.showMessageDialog(e.project, "Non Official X3 Plugin","NO X3 Plugin", Messages.getInformationIcon())
-    }
-    
+        val project = e.project ?: return
 
+        val organization = Messages.showInputDialog(
+            project,
+            "Enter organization name",
+            "New X3 Language Package",
+            Messages.getQuestionIcon()
+        ) ?: return
+
+        WriteCommandAction.runWriteCommandAction(project) {
+            val srcMainKotlin = VfsUtil.createDirectoryIfMissing(project.baseDir, "src/main/kotlin")
+            val packageDir = VfsUtil.createDirectoryIfMissing(srcMainKotlin, "com/$organization/x3/language")
+            val file = packageDir.findChild("Language.kt") ?: packageDir.createChildData(this, "Language.kt")
+            val content = "package com.$organization.x3.language\n\nclass Language"
+            VfsUtil.saveText(file, content)
+        }
+    }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -11,12 +11,12 @@
     <depends>com.intellij.java</depends>
 
     <actions>
-        <!-- Add your actions here -->
-        <group id="NOX3Plugin.MenuAction" text="NO X3 Lang" description="Non official X3 Language">
-            <add-to-group group-id="MainMenu" anchor="last" />
-            <action class="com.enterscript.noX3LanguagePlugin.MenuAction"
-                    id="actions.noX3LanguagePlugin.MenuAction" text="NOX3 Menu Action" />
-        </group>
+        <!-- Register action in the New menu -->
+        <action id="com.enterscript.noX3LanguagePlugin.MenuAction"
+                class="com.enterscript.noX3LanguagePlugin.MenuAction"
+                text="Create X3 Package">
+            <add-to-group group-id="NewGroup" anchor="last" />
+        </action>
     </actions>
 
     <extensions defaultExtensionNs="com.intellij">

--- a/src/test/kotlin/com/enterscript/noX3LanguagePlugin/MenuActionTest.kt
+++ b/src/test/kotlin/com/enterscript/noX3LanguagePlugin/MenuActionTest.kt
@@ -1,0 +1,29 @@
+package com.enterscript.noX3LanguagePlugin
+
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.ui.Messages
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.testFramework.PlatformTestCase
+import com.intellij.testFramework.TestActionEvent
+
+class MenuActionTest : PlatformTestCase() {
+    override fun setUp() {
+        super.setUp()
+        WriteCommandAction.runWriteCommandAction(project) {
+            VfsUtil.createDirectoryIfMissing(project.baseDir, "src/main/kotlin")
+        }
+    }
+
+    fun testCreatesPackageStructure() {
+        Messages.setTestInputDialog { "acme" }
+        try {
+            val action = MenuAction()
+            val event = TestActionEvent.createTestEvent(action)
+            action.actionPerformed(event)
+        } finally {
+            Messages.setTestInputDialog(null)
+        }
+        val file = project.baseDir.findFileByRelativePath("src/main/kotlin/com/acme/x3/language/Language.kt")
+        assertNotNull("Language.kt should be created", file)
+    }
+}


### PR DESCRIPTION
## Summary
- add menu action prompting for organization name and generating `com.<org>.x3.language` package
- register action in the IDE "New" menu
- add functional test for package generation

## Testing
- `./gradlew test --stacktrace` *(fails: Unsupported class file major version 63)*

------
https://chatgpt.com/codex/tasks/task_e_68a76a6cd4508322a03a66a241ccaf96