### PR TITLE
chore: define plugin id and update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # nox3-language
 
 ![Build](https://github.com/richardikeda/nox3-language-plugin/workflows/Build/badge.svg)
-[![Version](https://img.shields.io/jetbrains/plugin/v/PLUGIN_ID.svg)](https://plugins.jetbrains.com/plugin/PLUGIN_ID)
-[![Downloads](https://img.shields.io/jetbrains/plugin/d/PLUGIN_ID.svg)](https://plugins.jetbrains.com/plugin/PLUGIN_ID)
+[![Version](https://img.shields.io/jetbrains/plugin/v/com.enterscript.nox3language.svg)](https://plugins.jetbrains.com/plugin/com.enterscript.nox3language)
+[![Downloads](https://img.shields.io/jetbrains/plugin/d/com.enterscript.nox3language.svg)](https://plugins.jetbrains.com/plugin/com.enterscript.nox3language)
 
 ## Template ToDo list
 - [x] Create a new [IntelliJ Platform Plugin Template][template] project.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # IntelliJ Platform Artifacts Repositories
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 
-pluginGroup = com.enterscript.noX3LanguagePlugin
+pluginGroup = com.enterscript.nox3language
 pluginName = Non-Official X3 Plugin Language
 
 pluginVersion = 0.0.2

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,6 +1,6 @@
 <!-- Plugin Configuration File. Read more: https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html -->
 <idea-plugin>
-    <id>com.enterscript.noX3LanguagePlugin</id>
+    <id>com.enterscript.nox3language</id>
     <name>Non Official X3 Language</name>
     <vendor email="richard@enterscript.com" url="https://enterscript.com">Richard Ikeda</vendor>
     <description><![CDATA[ Non Official X3 Plugin.<br> <em>Basic X3 editor for IntelliJ</em> ]]></description>


### PR DESCRIPTION
## Summary
- use final plugin id `com.enterscript.nox3language`
- update README badges to reference published plugin id
- align Gradle pluginGroup with new id

## Testing
- `./gradlew test` *(fails: Failed to create Jar file /root/.gradle/caches/jars-9/b434e5cc9816519e3d9b77bd3c65f31a/jackson-core-2.16.0.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68a76a7f74b083229820ba13749660fe