### PR TITLE
chore: configure Qodana linter

### DIFF
--- a/qodana.yml
+++ b/qodana.yml
@@ -4,3 +4,6 @@
 version: 1.0
 profile:
   name: qodana.recommended
+linters:
+  - jetbrains/qodana-jvm
+


### PR DESCRIPTION
## Summary
- define JetBrains JVM linter in Qodana configuration

## Testing
- `./gradlew test` *(fails: Failed to create Jar file /root/.gradle/caches/jars-9/b434e5cc9816519e3d9b77bd3c65f31a/jackson-core-2.16.0.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68a77b5123408322b38197595a10edb6