### PR TITLE
chore: update Gradle to 9.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ platformPlugins = com.intellij.java
 javaVersion = 17
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 8.5
+gradleVersion = 9.0.0
 
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- upgrade Gradle wrapper configuration to 9.0.0
- set gradleVersion property to 9.0.0

## Testing
- `./gradlew --version --console=plain`
- `./gradlew build --console=plain` *(fails: NoSuchFileException gradle-base-diagnostics-9.0.0.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68b716bd561083229e6f653e63d47c12