### PR TITLE
refactor: adopt version catalog and new intellij platform plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,14 +13,15 @@ pluginUntilBuild = 233.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 2023.3
+platformVersion = 2024.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = com.intellij.java
+platformPlugins =
+platformBundledPlugins = com.intellij.java
 
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
-javaVersion = 17
+javaVersion = 21
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 9.0.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,22 @@
+[versions]
+# libraries
+junit = "4.13.2"
+opentest4j = "1.3.0"
+
+# plugins
+changelog = "2.4.0"
+intelliJPlatform = "2.7.2"
+kotlin = "2.2.0"
+kover = "0.9.1"
+qodana = "2025.1.1"
+
+[libraries]
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+opentest4j = { group = "org.opentest4j", name = "opentest4j", version.ref = "opentest4j" }
+
+[plugins]
+changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }
+intelliJPlatform = { id = "org.jetbrains.intellij.platform", version.ref = "intelliJPlatform" }
+kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
+qodana = { id = "org.jetbrains.qodana", version.ref = "qodana" }


### PR DESCRIPTION
## Summary
- move plugin and library versions to `gradle/libs.versions.toml`
- migrate build script to new `intellijPlatform` DSL and plugin aliases
- configure Kotlin toolchain 21 and remove detekt/test-junit usage

## Testing
- `./gradlew test` *(fails: Could not resolve all dependencies for configuration ':intellijPlatformTestClasspath'. No IntelliJ Platform dependency found with 'IC-2024.1 (installer)'.)*

------
https://chatgpt.com/codex/tasks/task_e_68b7192513188322b6a0ad1a941731b8