### PR TITLE
chore: update platform settings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,8 +32,21 @@ dependencies {
 
     intellijPlatform {
         create(properties("platformType"), properties("platformVersion"))
-        bundledPlugins("com.intellij.java")
-        plugins(providers.gradleProperty("platformPlugins").map { it.split(',') })
+        plugins(
+            providers.gradleProperty("platformPlugins").map {
+                it.split(',').map(String::trim).filter(String::isNotEmpty)
+            }
+        )
+        bundledPlugins(
+            providers.gradleProperty("platformBundledPlugins").map {
+                it.split(',').map(String::trim).filter(String::isNotEmpty)
+            }
+        )
+        bundledModules(
+            providers.gradleProperty("platformBundledModules").map {
+                it.split(',').map(String::trim).filter(String::isNotEmpty)
+            }
+        )
         testFramework(TestFrameworkType.Platform)
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,22 +3,23 @@
 
 pluginGroup = com.enterscript.nox3language
 pluginName = Non-Official X3 Plugin Language
+pluginRepositoryUrl =
 
 pluginVersion = 0.0.2
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 233
-pluginUntilBuild = 233.*
+pluginSinceBuild = 251
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 2024.1
+platformVersion = 2025.1.5
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins =
-platformBundledPlugins = com.intellij.java
+platformBundledPlugins =
+platformBundledModules =
 
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
 javaVersion = 21
@@ -30,4 +31,7 @@ gradleVersion = 9.0.0
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.
 # suppress inspection "UnusedProperty"
 kotlin.stdlib.default.dependency = false
+
+org.gradle.configuration-cache=true
+org.gradle.caching=true
 


### PR DESCRIPTION
## Summary
- target IntelliJ Platform 2025.1.5 and since build 251
- add placeholders for plugin repository and platform dependencies
- enable Gradle caching options

## Testing
- `./gradlew test` *(fails: Could not resolve all dependencies for configuration ':intellijPlatformTestClasspath' - No IntelliJ Platform dependency found with 'IC-2025.1.5 (installer)')*

------
https://chatgpt.com/codex/tasks/task_e_68b71be58b4c8322814781c46beb7023