### PR TITLE
Add Foojay resolver plugin

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,5 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 rootProject.name = "nox3-language"


### PR DESCRIPTION
## Summary
- add org.gradle.toolchains.foojay-resolver-convention plugin to Gradle settings

## Testing
- `./gradlew build` *(fails: No IntelliJ Platform dependency found with 'IC-2025.1.5 (installer)')*

------
https://chatgpt.com/codex/tasks/task_e_68b72144628c8322ac576e22398de253