### PR TITLE
Configure Qodana and Kover, drop detekt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
 
       # Run tests
       - name: Run Tests
-        run: ./gradlew check
+        run: ./gradlew check koverXmlReport
 
       # Collect Tests Result of failed tests
       - name: Collect Tests Result

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,6 +80,26 @@ intellijPlatform {
     }
 }
 
+qodana {
+    projectPath.set(projectDir.absolutePath)
+    cachePath.set(layout.projectDirectory.dir(".qodana").asFile.absolutePath)
+    resultsPath.set(layout.buildDirectory.dir("qodana").map { it.asFile.absolutePath })
+}
+
+kover {
+    reports {
+        total {
+            html {
+                onCheck.set(true)
+            }
+            xml {
+                onCheck.set(true)
+                xmlFile.set(layout.buildDirectory.file("reports/kover/report.xml"))
+            }
+        }
+    }
+}
+
 tasks {
     named("verifyPlugin") {
         dependsOn("test")

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -1,8 +1,0 @@
-# Default detekt configuration:
-# https://github.com/detekt/detekt/blob/master/detekt-core/src/main/resources/default-detekt-config.yml
-
-formatting:
-  Indentation:
-    continuationIndentSize: 8
-  ParameterListWrapping:
-    indentSize: 8


### PR DESCRIPTION
## Summary
- remove obsolete detekt configuration file
- wire Qodana plugin using existing qodana.yml and configure cache and results paths
- enable Kover coverage reports and integrate XML report into CI workflow

## Testing
- `./gradlew --console=plain check koverXmlReport` *(fails: No IntelliJ Platform dependency found)*
