### PR TITLE
chore: ignore IntelliJ platform artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 .idea
+.intellijPlatform/
 build
 /src/test/kotlin/com/enterscript/noX3LanguagePlugin/MyPluginTest.kt
 /build/gen/


### PR DESCRIPTION
## Summary
- ignore generated `.intellijPlatform` directory

## Testing
- `./gradlew test` *(fails: Could not resolve org.jetbrains.intellij.deps.jflex:jflex:1.9.2 - HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b734c29ad883229a0496b30dbfd19f