### PR TITLE
Use basePath and modern write APIs

### DIFF
--- a/src/main/kotlin/com/enterscript/nox3languageplugin/MenuAction.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/MenuAction.kt
@@ -2,9 +2,11 @@ package com.enterscript.nox3languageplugin
 
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.ui.Messages
-import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.LocalFileSystem
+import java.nio.file.Files
+import java.nio.file.Path
 
 /**
  * Action that creates the X3 language package structure.
@@ -20,12 +22,16 @@ class MenuAction : AnAction() {
             Messages.getQuestionIcon()
         ) ?: return
 
-        WriteCommandAction.runWriteCommandAction(project) {
-            val srcMainKotlin = VfsUtil.createDirectoryIfMissing(project.baseDir, "src/main/kotlin")
-            val packageDir = VfsUtil.createDirectoryIfMissing(srcMainKotlin, "com/$organization/x3/language")
-            val file = packageDir.findChild("Language.kt") ?: packageDir.createChildData(this, "Language.kt")
-            val content = "package com.$organization.x3.language\n\nclass Language"
-            VfsUtil.saveText(file, content)
+        val basePath = project.basePath ?: return
+
+        runWriteAction {
+            val packagePath = Path.of(basePath, "src", "main", "kotlin", "com", organization, "x3", "language")
+            Files.createDirectories(packagePath)
+            val filePath = packagePath.resolve("Language.kt")
+            if (!Files.exists(filePath)) {
+                Files.writeString(filePath, "package com.$organization.x3.language\n\nclass Language")
+            }
+            LocalFileSystem.getInstance().refreshAndFindFileByPath(filePath.toString())
         }
     }
 }

--- a/src/test/kotlin/com/enterscript/nox3languageplugin/MenuActionTest.kt
+++ b/src/test/kotlin/com/enterscript/nox3languageplugin/MenuActionTest.kt
@@ -1,16 +1,20 @@
 package com.enterscript.nox3languageplugin
 
-import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.ui.Messages
-import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.testFramework.PlatformTestCase
 import com.intellij.testFramework.TestActionEvent
+import java.nio.file.Files
+import java.nio.file.Path
 
 class MenuActionTest : PlatformTestCase() {
     override fun setUp() {
         super.setUp()
-        WriteCommandAction.runWriteCommandAction(project) {
-            VfsUtil.createDirectoryIfMissing(project.baseDir, "src/main/kotlin")
+        runWriteAction {
+            val srcPath = Path.of(project.basePath!!, "src", "main", "kotlin")
+            Files.createDirectories(srcPath)
+            LocalFileSystem.getInstance().refreshAndFindFileByPath(srcPath.toString())
         }
     }
 
@@ -23,7 +27,8 @@ class MenuActionTest : PlatformTestCase() {
         } finally {
             Messages.setTestInputDialog(null)
         }
-        val file = project.baseDir.findFileByRelativePath("src/main/kotlin/com/acme/x3/language/Language.kt")
+        val filePath = Path.of(project.basePath!!, "src", "main", "kotlin", "com", "acme", "x3", "language", "Language.kt")
+        val file = LocalFileSystem.getInstance().refreshAndFindFileByPath(filePath.toString())
         assertNotNull("Language.kt should be created", file)
     }
 }


### PR DESCRIPTION
## Summary
- use project.basePath with `Path` and `LocalFileSystem` to create X3 language structure
- migrate tests to runWriteAction and filesystem API

## Testing
- `./gradlew test` *(fails: Could not resolve org.jetbrains.intellij.deps.jflex:jflex:1.9.2. Received status code 403 from server: Forbidden)*

