### PR TITLE
Use lowercase package for NOX3 grammar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,15 +59,15 @@ sourceSets["main"].kotlin.srcDir("build/gen")
 
 val generateNOX3Lexer by tasks.registering(GenerateLexerTask::class) {
     sourceFile.set(file("src/main/grammars/NOX3.flex"))
-    targetOutputDir.set(layout.buildDirectory.dir("gen/com/enterscript/noX3LanguagePlugin/language/lexer"))
+    targetOutputDir.set(layout.buildDirectory.dir("gen/com/enterscript/nox3languageplugin/language/lexer"))
     purgeOldFiles.set(true)
 }
 
 val generateNOX3Parser by tasks.registering(GenerateParserTask::class) {
     sourceFile.set(file("src/main/grammars/NOX3.bnf"))
     targetRootOutputDir.set(layout.buildDirectory.dir("gen"))
-    pathToParser.set("com/enterscript/noX3LanguagePlugin/language/psi/impl/parser/NOX3Parser")
-    pathToPsiRoot.set("com/enterscript/noX3LanguagePlugin/language/psi")
+    pathToParser.set("com/enterscript/nox3languageplugin/language/psi/impl/parser/NOX3Parser")
+    pathToPsiRoot.set("com/enterscript/nox3languageplugin/language/psi")
     purgeOldFiles.set(true)
 }
 

--- a/src/main/grammars/NOX3.bnf
+++ b/src/main/grammars/NOX3.bnf
@@ -1,18 +1,18 @@
 {
-  parserClass="com.enterscript.noX3LanguagePlugin.language.psi.impl.parser.NOX3Parser"
+  parserClass="com.enterscript.nox3languageplugin.language.psi.impl.parser.NOX3Parser"
 
   extends="com.intellij.extapi.psi.ASTWrapperPsiElement"
 
   psiClassPrefix="NOX3"
   psiImplClassSuffix="Impl"
-  psiPackage="com.enterscript.noX3LanguagePlugin.language.psi"
-  psiImplPackage="com.enterscript.noX3LanguagePlugin.language.psi.impl"
+  psiPackage="com.enterscript.nox3languageplugin.language.psi"
+  psiImplPackage="com.enterscript.nox3languageplugin.language.psi.impl"
 
-  elementTypeHolderClass="com.enterscript.noX3LanguagePlugin.language.psi.NOX3Types"
-  elementTypeClass="com.enterscript.noX3LanguagePlugin.language.psi.NOX3ElementType"
-  tokenTypeClass="com.enterscript.noX3LanguagePlugin.language.psi.NOX3TokenType"
+  elementTypeHolderClass="com.enterscript.nox3languageplugin.language.psi.NOX3Types"
+  elementTypeClass="com.enterscript.nox3languageplugin.language.psi.NOX3ElementType"
+  tokenTypeClass="com.enterscript.nox3languageplugin.language.psi.NOX3TokenType"
 
-  psiImplUtilClass="com.enterscript.noX3LanguagePlugin.language.psi.impl.NOX3PsiImplUtil"
+  psiImplUtilClass="com.enterscript.nox3languageplugin.language.psi.impl.NOX3PsiImplUtil"
 }
 
 file ::= element_*
@@ -20,8 +20,8 @@ file ::= element_*
 private element_ ::= (property | if_statement | for_statement | COMMENT | CRLF)
 
 property ::= IDENTIFIER SEPARATOR value {
-    mixin="com.enterscript.noX3LanguagePlugin.language.psi.impl.NOX3NamedElementImpl"
-    implements="com.enterscript.noX3LanguagePlugin.language.psi.NOX3NamedElement"
+    mixin="com.enterscript.nox3languageplugin.language.psi.impl.NOX3NamedElementImpl"
+    implements="com.enterscript.nox3languageplugin.language.psi.NOX3NamedElement"
     methods=[getKey getValue getName setName getNameIdentifier]
 }
 

--- a/src/main/grammars/NOX3.flex
+++ b/src/main/grammars/NOX3.flex
@@ -1,8 +1,8 @@
-package com.enterscript.noX3LanguagePlugin.language.lexer;
+package com.enterscript.nox3languageplugin.language.lexer;
 
 import com.intellij.lexer.FlexLexer;
 import com.intellij.psi.tree.IElementType;
-import com.enterscript.noX3LanguagePlugin.language.psi.NOX3Types;
+import com.enterscript.nox3languageplugin.language.psi.NOX3Types;
 import com.intellij.psi.TokenType;
 
 %%


### PR DESCRIPTION
## Summary
- normalize NOX3 grammar package and imports to `com.enterscript.nox3languageplugin`
- update Gradle grammar generation paths to new package

## Testing
- `./gradlew generateNOX3Lexer generateNOX3Parser` *(fails: Could not resolve org.jetbrains.intellij.deps.jflex:jflex:1.9.2)*

------
https://chatgpt.com/codex/tasks/task_e_68b7415e901483229d6b3a01abad0671