### PR TITLE
Use generated lexer and parser for NOX3

### DIFF
--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3Reference.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3Reference.kt
@@ -1,7 +1,7 @@
 package com.enterscript.nox3languageplugin.language
 
 import com.enterscript.nox3languageplugin.icons.NOX3Icons
-import com.enterscript.nox3languageplugin.language.psi.NOX3Variable
+import com.enterscript.noX3LanguagePlugin.language.psi.NOX3Variable
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.openapi.util.TextRange

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3Util.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3Util.kt
@@ -1,7 +1,7 @@
 package com.enterscript.nox3languageplugin.language
 
-import com.enterscript.nox3languageplugin.language.psi.NOX3File
-import com.enterscript.nox3languageplugin.language.psi.NOX3Variable
+import com.enterscript.noX3LanguagePlugin.language.psi.NOX3File
+import com.enterscript.noX3LanguagePlugin.language.psi.NOX3Variable
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiManager
 import com.intellij.psi.search.FileTypeIndex

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/lexer/NOX3LexerAdapter.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/lexer/NOX3LexerAdapter.kt
@@ -1,0 +1,6 @@
+package com.enterscript.nox3languageplugin.language.lexer
+
+import com.enterscript.noX3LanguagePlugin.language.lexer._NOX3Lexer
+import com.intellij.lexer.FlexAdapter
+
+class NOX3LexerAdapter : FlexAdapter(_NOX3Lexer(null))

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/parser/NOX3ParserDefinition.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/parser/NOX3ParserDefinition.kt
@@ -1,10 +1,10 @@
 package com.enterscript.nox3languageplugin.language.parser
 
 import com.enterscript.nox3languageplugin.language.NOX3Language
-import com.enterscript.nox3languageplugin.language.lexer.NOX3Lexer
-import com.enterscript.nox3languageplugin.language.psi.NOX3File
-import com.enterscript.nox3languageplugin.language.psi.NOX3Types
-import com.enterscript.nox3languageplugin.language.psi.impl.parser.NOX3Parser
+import com.enterscript.nox3languageplugin.language.lexer.NOX3LexerAdapter
+import com.enterscript.noX3LanguagePlugin.language.psi.NOX3File
+import com.enterscript.noX3LanguagePlugin.language.psi.NOX3Types
+import com.enterscript.noX3LanguagePlugin.language.psi.impl.parser.NOX3Parser
 import com.intellij.lang.ASTNode
 import com.intellij.lang.ParserDefinition
 import com.intellij.lang.PsiParser
@@ -23,7 +23,7 @@ class NOX3ParserDefinition : ParserDefinition {
         val FILE: IFileElementType = IFileElementType(NOX3Language.INSTANCE)
     }
 
-    override fun createLexer(project: Project) = NOX3Lexer()
+    override fun createLexer(project: Project) = NOX3LexerAdapter()
     override fun getWhitespaceTokens(): TokenSet = WHITE_SPACES
     override fun getCommentTokens(): TokenSet = COMMENTS
     override fun getStringLiteralElements(): TokenSet = TokenSet.EMPTY

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/NOX3File.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/NOX3File.kt
@@ -1,4 +1,4 @@
-package com.enterscript.nox3languageplugin.language.psi
+package com.enterscript.noX3LanguagePlugin.language.psi
 
 import com.enterscript.nox3languageplugin.language.NOX3FileType
 import com.enterscript.nox3languageplugin.language.NOX3Language

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/NOX3Function.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/NOX3Function.kt
@@ -1,3 +1,3 @@
-package com.enterscript.nox3languageplugin.language.psi
+package com.enterscript.noX3LanguagePlugin.language.psi
 
 interface NOX3Function : NOX3NamedElement

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/NOX3Module.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/NOX3Module.kt
@@ -1,3 +1,3 @@
-package com.enterscript.nox3languageplugin.language.psi
+package com.enterscript.noX3LanguagePlugin.language.psi
 
 interface NOX3Module : NOX3NamedElement

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/NOX3NamedElement.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/NOX3NamedElement.kt
@@ -1,4 +1,4 @@
-package com.enterscript.nox3languageplugin.language.psi
+package com.enterscript.noX3LanguagePlugin.language.psi
 
 import com.intellij.psi.PsiNameIdentifierOwner
 

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/NOX3Variable.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/NOX3Variable.kt
@@ -1,3 +1,3 @@
-package com.enterscript.nox3languageplugin.language.psi
+package com.enterscript.noX3LanguagePlugin.language.psi
 
 interface NOX3Variable : NOX3NamedElement

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/structure/NOX3StructureViewFactory.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/structure/NOX3StructureViewFactory.kt
@@ -1,7 +1,7 @@
 package com.enterscript.nox3languageplugin.language.structure
 
-import com.enterscript.nox3languageplugin.language.psi.NOX3File
-import com.enterscript.nox3languageplugin.language.psi.NOX3Property
+import com.enterscript.noX3LanguagePlugin.language.psi.NOX3File
+import com.enterscript.noX3LanguagePlugin.language.psi.NOX3Property
 import com.intellij.ide.structureView.StructureViewBuilder
 import com.intellij.ide.structureView.StructureViewModel
 import com.intellij.ide.structureView.StructureViewTreeElement

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/syntax/NOX3SyntaxHighlighter.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/syntax/NOX3SyntaxHighlighter.kt
@@ -1,7 +1,7 @@
 package com.enterscript.nox3languageplugin.language.syntax
 
 import com.enterscript.nox3languageplugin.language.lexer.NOX3LexerAdapter
-import com.enterscript.nox3languageplugin.language.psi.NOX3Types
+import com.enterscript.noX3LanguagePlugin.language.psi.NOX3Types
 import com.intellij.lexer.Lexer
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
 import com.intellij.openapi.editor.HighlighterColors

--- a/src/test/kotlin/com/enterscript/nox3languageplugin/language/NOX3NavigationTest.kt
+++ b/src/test/kotlin/com/enterscript/nox3languageplugin/language/NOX3NavigationTest.kt
@@ -1,6 +1,6 @@
 package com.enterscript.nox3languageplugin.language
 
-import com.enterscript.nox3languageplugin.language.psi.NOX3Property
+import com.enterscript.noX3LanguagePlugin.language.psi.NOX3Property
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/src/test/kotlin/com/enterscript/nox3languageplugin/language/NOX3StructureViewFactoryTest.kt
+++ b/src/test/kotlin/com/enterscript/nox3languageplugin/language/NOX3StructureViewFactoryTest.kt
@@ -1,6 +1,6 @@
 package com.enterscript.nox3languageplugin.language
 
-import com.enterscript.nox3languageplugin.language.psi.NOX3File
+import com.enterscript.noX3LanguagePlugin.language.psi.NOX3File
 import com.enterscript.nox3languageplugin.language.structure.NOX3StructureViewFactory
 import com.intellij.ide.structureView.StructureViewTreeElement
 import com.intellij.testFramework.fixtures.BasePlatformTestCase

--- a/src/test/kotlin/com/enterscript/nox3languageplugin/language/lexer/NOX3LexerTest.kt
+++ b/src/test/kotlin/com/enterscript/nox3languageplugin/language/lexer/NOX3LexerTest.kt
@@ -1,7 +1,7 @@
 package com.enterscript.nox3languageplugin.language.lexer
 
 import com.enterscript.nox3languageplugin.language.lexer.NOX3LexerAdapter
-import com.enterscript.nox3languageplugin.language.psi.NOX3Types
+import com.enterscript.noX3LanguagePlugin.language.psi.NOX3Types
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/src/test/kotlin/com/enterscript/nox3languageplugin/language/parser/NOX3ParserTest.kt
+++ b/src/test/kotlin/com/enterscript/nox3languageplugin/language/parser/NOX3ParserTest.kt
@@ -1,8 +1,8 @@
 package com.enterscript.nox3languageplugin.language.parser
 
 import com.enterscript.nox3languageplugin.language.NOX3FileType
-import com.enterscript.nox3languageplugin.language.psi.NOX3File
-import com.enterscript.nox3languageplugin.language.psi.NOX3Property
+import com.enterscript.noX3LanguagePlugin.language.psi.NOX3File
+import com.enterscript.noX3LanguagePlugin.language.psi.NOX3Property
 import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.testFramework.fixtures.BasePlatformTestCase

--- a/src/test/kotlin/com/enterscript/nox3languageplugin/language/psi/NOX3PsiCreationTest.kt
+++ b/src/test/kotlin/com/enterscript/nox3languageplugin/language/psi/NOX3PsiCreationTest.kt
@@ -1,4 +1,4 @@
-package com.enterscript.nox3languageplugin.language.psi
+package com.enterscript.noX3LanguagePlugin.language.psi
 
 import com.enterscript.nox3languageplugin.language.NOX3FileType
 import com.intellij.psi.PsiFileFactory


### PR DESCRIPTION
## Summary
- wrap the generated `_NOX3Lexer` with a new `NOX3LexerAdapter`
- wire `NOX3ParserDefinition` and project sources to the generated lexer, parser, and PSI types
- update tests for the new PSI package

## Testing
- `./gradlew test` *(fails: Could not resolve org.jetbrains.intellij.deps.jflex:jflex:1.9.2)*

------
https://chatgpt.com/codex/tasks/task_e_68b7416a933c83228bcca237eb561877