### PR TITLE
Add NOX3 extension stubs with English metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,7 @@
 - File Icon
 ### Added
 - Initial scaffold created from [IntelliJ Platform Plugin Template](https://github.com/JetBrains/intellij-platform-plugin-template)
+
+## [0.0.2]
+### Added
+- Base classes for NOX3 annotator, reference contributor, refactoring support, and line marker provider

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3Annotator.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3Annotator.kt
@@ -1,0 +1,21 @@
+package com.enterscript.nox3languageplugin.language
+
+import com.intellij.lang.annotation.Annotator
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiLiteralExpression
+
+/**
+ * Provides simple annotation support for NOX3 string literals.
+ */
+class NOX3Annotator : Annotator {
+    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+        // Placeholder annotator. Real highlighting will be implemented later.
+        if (element !is PsiLiteralExpression) return
+    }
+
+    companion object {
+        const val NOX3_PREFIX_STR: String = "nox"
+        const val NOX3_SEPARATOR_STR: String = ":"
+    }
+}

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3LineMarkerProvider.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3LineMarkerProvider.kt
@@ -1,0 +1,14 @@
+package com.enterscript.nox3languageplugin.language
+
+import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
+import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider
+import com.intellij.psi.PsiElement
+
+/**
+ * Provides line markers for NOX3-related code.
+ */
+class NOX3LineMarkerProvider : RelatedItemLineMarkerProvider() {
+    override fun collectNavigationMarkers(element: PsiElement, result: MutableCollection<in RelatedItemLineMarkerInfo<*>>) {
+        // Placeholder implementation. Line markers will be added later.
+    }
+}

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3RefactoringSupportProvider.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3RefactoringSupportProvider.kt
@@ -1,0 +1,8 @@
+package com.enterscript.nox3languageplugin.language
+
+import com.intellij.lang.refactoring.RefactoringSupportProvider
+
+/**
+ * Enables basic refactoring support for NOX3 elements.
+ */
+class NOX3RefactoringSupportProvider : RefactoringSupportProvider()

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3ReferenceContributor.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3ReferenceContributor.kt
@@ -1,0 +1,26 @@
+package com.enterscript.nox3languageplugin.language
+
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiReference
+import com.intellij.psi.PsiReferenceContributor
+import com.intellij.psi.PsiReferenceRegistrar
+import com.intellij.psi.PsiReferenceProvider
+import com.intellij.util.ProcessingContext
+
+/**
+ * Registers reference providers for NOX3 elements.
+ */
+class NOX3ReferenceContributor : PsiReferenceContributor() {
+    override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) {
+        // Placeholder implementation. Reference providers will be added later.
+        registrar.registerReferenceProvider(
+            PlatformPatterns.psiElement(),
+            object : PsiReferenceProvider() {
+                override fun getReferencesByElement(element: PsiElement, context: ProcessingContext): Array<PsiReference> {
+                    return PsiReference.EMPTY_ARRAY
+                }
+            }
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- keep plugin name, descriptions, and action labels in English
- add stub implementations for NOX3 annotator, reference contributor, refactoring support and line marker provider
- record changes in changelog

## Testing
- `./gradlew build` *(fails: Could not resolve com.jetbrains.intellij.java:java-compiler-ant-tasks... 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b749b7ec9c8322b685ce220d7d2c46