### PR TITLE
style: format NOX3 language classes

### DIFF
--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3FileType.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3FileType.kt
@@ -4,9 +4,9 @@ import com.enterscript.nox3languageplugin.icons.NOX3Icons
 import com.intellij.openapi.fileTypes.LanguageFileType
 import javax.swing.Icon
 
-class NOX3FileType private constructor(): LanguageFileType(NOX3Language.INSTANCE) {
+class NOX3FileType private constructor() : LanguageFileType(NOX3Language.INSTANCE) {
 
-    override fun getName()= "X3 Language"
+    override fun getName() = "X3 Language"
 
     override fun getDescription() = "X3 language file"
 

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3Language.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3Language.kt
@@ -2,10 +2,10 @@ package com.enterscript.nox3languageplugin.language
 
 import com.intellij.lang.Language
 
-class  NOX3Language private constructor() : Language("X3") {
+class NOX3Language private constructor() : Language("X3") {
     companion object {
         @JvmField
-        val INSTANCE  = NOX3Language()
+        val INSTANCE = NOX3Language()
     }
 
 }


### PR DESCRIPTION
## Summary
- tidy spacing in `NOX3Language` definition and singleton
- normalize spacing and constructor style in `NOX3FileType`

## Testing
- `./gradlew ktlintFormat` *(fails: Task 'ktlintFormat' not found)*
- `./gradlew test` *(fails: Could not resolve com.jetbrains.intellij.java:java-compiler-ant-tasks)*

------
https://chatgpt.com/codex/tasks/task_e_68b74d648c5483228d989089aa212964