### PR TITLE
Align plugin namespace with package structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # nox3-language
 
 ![Build](https://github.com/richardikeda/nox3-language-plugin/workflows/Build/badge.svg)
-[![Version](https://img.shields.io/jetbrains/plugin/v/com.enterscript.nox3language.svg)](https://plugins.jetbrains.com/plugin/com.enterscript.nox3language)
-[![Downloads](https://img.shields.io/jetbrains/plugin/d/com.enterscript.nox3language.svg)](https://plugins.jetbrains.com/plugin/com.enterscript.nox3language)
+[![Version](https://img.shields.io/jetbrains/plugin/v/com.enterscript.nox3languageplugin.svg)](https://plugins.jetbrains.com/plugin/com.enterscript.nox3languageplugin)
+[![Downloads](https://img.shields.io/jetbrains/plugin/d/com.enterscript.nox3languageplugin.svg)](https://plugins.jetbrains.com/plugin/com.enterscript.nox3languageplugin)
 
 <!-- Plugin description -->
 nox3-language is an IntelliJ Platform plugin that adds support for X3-Language (L4J) used in Sage ERP X3.
@@ -13,13 +13,13 @@ Everyone can contribute.
 
 In the future we will implement:
 
-- A way to generate `com.enterscript.nox3language` packages
+- A way to generate `com.enterscript.nox3languageplugin` packages
 - Function and call verification
 - An unofficial way of working with code versions of .src on X3.
 - Dark theme
 - AutoComplete of classes, functions, subprogs, and references.
 
-The plugin is available on the [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/com.enterscript.nox3language).
+The plugin is available on the [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/com.enterscript.nox3languageplugin).
 
 Thanks for your contributions!
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # IntelliJ Platform Artifacts Repositories
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 
-pluginGroup = com.enterscript.nox3language
+pluginGroup = com.enterscript.nox3languageplugin
 pluginName = Non-Official X3 Plugin Language
 pluginRepositoryUrl = https://github.com/richardikeda/nox3-language-plugin
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
-rootProject.name = "nox3-language"
+rootProject.name = "nox3-language-plugin"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,6 +1,6 @@
 <!-- Plugin Configuration File. Read more: https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html -->
 <idea-plugin>
-    <id>com.enterscript.nox3language</id>
+    <id>com.enterscript.nox3languageplugin</id>
     <name>Non Official X3 Language</name>
     <vendor email="richard@enterscript.com" url="https://enterscript.com">Richard Ikeda</vendor>
     <description><![CDATA[ Non Official X3 Plugin.<br> <em>Basic X3 editor for IntelliJ</em> ]]></description>


### PR DESCRIPTION
## Summary
- switch default namespace to `com.enterscript.nox3languageplugin`
- update Gradle plugin group and plugin ID
- rename root project and README references

## Testing
- `./gradlew test` *(fails: Could not resolve com.jetbrains.intellij.java:java-compiler-ant-tasks due to 403 Forbidden)*
