### PR TITLE
feat: extend grammar with glossary tokens

### DIFF
--- a/src/main/grammars/NOX3.bnf
+++ b/src/main/grammars/NOX3.bnf
@@ -17,7 +17,7 @@
 
 file ::= element_*
 
-private element_ ::= (property | if_statement | for_statement | COMMENT | CRLF)
+private element_ ::= (property | if_statement | for_statement | case_statement | repeat_statement | COMMENT | CRLF)
 
 property ::= IDENTIFIER SEPARATOR value {
     mixin="com.enterscript.nox3languageplugin.language.psi.impl.NOX3NamedElementImpl"
@@ -29,6 +29,12 @@ if_statement ::= IF expression CRLF element_* ENDIF
 
 for_statement ::= FOR IDENTIFIER SEPARATOR expression TO expression CRLF element_* ENDFOR
 
+case_statement ::= CASE expression CRLF (WHEN expression CRLF element_*)+ ENDCASE
+
+repeat_statement ::= REPEAT CRLF element_* UNTIL expression
+
 value ::= expression
 
-expression ::= NUMBER | STRING | IDENTIFIER
+function_call ::= (IDENTIFIER | PRINT | LEN | SQRT) '(' expression? ')'
+
+expression ::= NUMBER | STRING | IDENTIFIER | USER | SYSDATE | function_call

--- a/src/main/grammars/NOX3.flex
+++ b/src/main/grammars/NOX3.flex
@@ -26,6 +26,18 @@ ENDIF=(?i:endif)
 FOR=(?i:for)
 TO=(?i:to)
 ENDFOR=(?i:endfor)
+ELSE=(?i:else)
+WHILE=(?i:while)
+CASE=(?i:case)
+WHEN=(?i:when)
+ENDCASE=(?i:endcase)
+REPEAT=(?i:repeat)
+UNTIL=(?i:until)
+PRINT=(?i:print)
+LEN=(?i:len)
+SQRT=(?i:sqrt)
+USER=(?i:user)
+SYSDATE=(?i:sysdate)
 
 %%
 
@@ -38,6 +50,18 @@ ENDFOR=(?i:endfor)
 {FOR}         { return NOX3Types.FOR; }
 {TO}          { return NOX3Types.TO; }
 {ENDFOR}      { return NOX3Types.ENDFOR; }
+{ELSE}        { return NOX3Types.ELSE; }
+{WHILE}       { return NOX3Types.WHILE; }
+{CASE}        { return NOX3Types.CASE; }
+{WHEN}        { return NOX3Types.WHEN; }
+{ENDCASE}     { return NOX3Types.ENDCASE; }
+{REPEAT}      { return NOX3Types.REPEAT; }
+{UNTIL}       { return NOX3Types.UNTIL; }
+{PRINT}       { return NOX3Types.PRINT; }
+{LEN}         { return NOX3Types.LEN; }
+{SQRT}        { return NOX3Types.SQRT; }
+{USER}        { return NOX3Types.USER; }
+{SYSDATE}     { return NOX3Types.SYSDATE; }
 
 "="           { return NOX3Types.SEPARATOR; }
 {STRING}      { return NOX3Types.STRING; }

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3CompletionContributor.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3CompletionContributor.kt
@@ -21,11 +21,8 @@ class NOX3CompletionContributor : CompletionContributor() {
                     context: ProcessingContext,
                     resultSet: CompletionResultSet
                 ) {
-                    // keywords
-                    KEYWORDS.forEach { resultSet.addElement(LookupElementBuilder.create(it)) }
-
-                    // built‑in functions
-                    FUNCTIONS.forEach { resultSet.addElement(LookupElementBuilder.create("$it()")) }
+                    // glossary terms
+                    GLOSSARY.forEach { resultSet.addElement(LookupElementBuilder.create(it)) }
 
                     // project symbols (property keys)
                     val project = parameters.position.project
@@ -38,7 +35,13 @@ class NOX3CompletionContributor : CompletionContributor() {
     }
 
     private companion object {
-        val KEYWORDS = listOf("if", "else", "while", "function")
-        val FUNCTIONS = listOf("print", "len", "sqrt")
+        val GLOSSARY = listOf(
+            // instructions
+            "if", "endif", "for", "to", "endfor", "else", "while", "case", "when", "endcase", "repeat", "until",
+            // system variables
+            "user", "sysdate",
+            // functions
+            "print()", "len()", "sqrt()"
+        )
     }
 }

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/syntax/NOX3SyntaxHighlighter.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/syntax/NOX3SyntaxHighlighter.kt
@@ -24,10 +24,14 @@ class NOX3SyntaxHighlighter : SyntaxHighlighterBase() {
         private val SEPARATOR: TextAttributesKey = createTextAttributesKey("NOX3_SEPARATOR", DefaultLanguageHighlighterColors.OPERATION_SIGN)
 
         private val keys = HashMap<IElementType, TextAttributesKey>().apply {
-            put(NOX3Types.KEY, KEYWORD)
-            put(NOX3Types.VALUE, STRING)
+            listOf(
+                NOX3Types.IF, NOX3Types.ENDIF, NOX3Types.FOR, NOX3Types.TO, NOX3Types.ENDFOR,
+                NOX3Types.ELSE, NOX3Types.WHILE, NOX3Types.CASE, NOX3Types.WHEN, NOX3Types.ENDCASE,
+                NOX3Types.REPEAT, NOX3Types.UNTIL, NOX3Types.PRINT, NOX3Types.LEN, NOX3Types.SQRT,
+                NOX3Types.USER, NOX3Types.SYSDATE
+            ).forEach { put(it, KEYWORD) }
+            put(NOX3Types.STRING, STRING)
             put(NOX3Types.COMMENT, COMMENT)
-            put(NOX3Types.COMMENT_MULTI_LINE, COMMENT)
             put(NOX3Types.SEPARATOR, SEPARATOR)
             put(TokenType.BAD_CHARACTER, BAD_CHARACTER)
         }

--- a/src/test/kotlin/com/enterscript/nox3languageplugin/language/NOX3CompletionContributorTest.kt
+++ b/src/test/kotlin/com/enterscript/nox3languageplugin/language/NOX3CompletionContributorTest.kt
@@ -8,8 +8,9 @@ class NOX3CompletionContributorTest : BasePlatformTestCase() {
         myFixture.addFileToProject("other.nox3", "projectKey=1")
         myFixture.configureByText("test.nox3", "<caret>")
         val completions = myFixture.completeBasic().map { it.lookupString }
-        assertTrue("if" in completions)
-        assertTrue("print()" in completions)
+        assertTrue("case" in completions)
+        assertTrue("user" in completions)
+        assertTrue("len()" in completions)
         assertTrue("projectKey" in completions)
     }
 }

--- a/src/test/kotlin/com/enterscript/nox3languageplugin/language/NOX3SyntaxHighlighterTest.kt
+++ b/src/test/kotlin/com/enterscript/nox3languageplugin/language/NOX3SyntaxHighlighterTest.kt
@@ -9,10 +9,10 @@ class NOX3SyntaxHighlighterTest : BasePlatformTestCase() {
         val highlighter = NOX3SyntaxHighlighter()
         val lexer = highlighter.highlightingLexer
 
-        lexer.start("key=value")
+        lexer.start("case")
         assertEquals(NOX3SyntaxHighlighter.KEYWORD, highlighter.getTokenHighlights(lexer.tokenType)[0])
-        lexer.advance() // separator
-        lexer.advance()
+
+        lexer.start("\"text\"")
         assertEquals(NOX3SyntaxHighlighter.STRING, highlighter.getTokenHighlights(lexer.tokenType)[0])
 
         lexer.start("#comment")

--- a/src/test/kotlin/com/enterscript/nox3languageplugin/language/lexer/NOX3LexerTest.kt
+++ b/src/test/kotlin/com/enterscript/nox3languageplugin/language/lexer/NOX3LexerTest.kt
@@ -7,13 +7,17 @@ import kotlin.test.assertEquals
 
 class NOX3LexerTest {
     @Test
-    fun testTokens() {
+    fun testKeywordToken() {
         val lexer = NOX3LexerAdapter()
-        lexer.start("foo:bar")
-        assertEquals(NOX3Types.KEY, lexer.tokenType)
-        lexer.advance()
-        assertEquals(NOX3Types.SEPARATOR, lexer.tokenType)
-        lexer.advance()
-        assertEquals(NOX3Types.VALUE, lexer.tokenType)
+        lexer.start("case")
+        assertEquals(NOX3Types.CASE, lexer.tokenType)
+    }
+
+    @Test
+    fun testFunctionToken() {
+        val lexer = NOX3LexerAdapter()
+        lexer.start("print")
+        assertEquals(NOX3Types.PRINT, lexer.tokenType)
     }
 }
+


### PR DESCRIPTION
## Summary
- add case, repeat and glossary tokens to lexer
- support CASE/WHEN and REPEAT/UNTIL plus function calls in grammar
- unify completion glossary and adjust syntax highlighting
- test new tokens and completions

## Testing
- `./gradlew generateLexer generateParser test` *(fails: 403 Forbidden from cache-redirector.jetbrains.com)*

------
https://chatgpt.com/codex/tasks/task_e_68b75e3e309c8322b7d7e0f194ef0199