### PR TITLE
Add brace matcher and folding builder

### DIFF
--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/X3RuleService.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/X3RuleService.kt
@@ -1,0 +1,48 @@
+package com.enterscript.nox3languageplugin.language
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+/**
+ * Service loading X3 language rule information from the CSV file shipped with the plugin.
+ * Only a very small subset of columns is required by the consumers. The service exposes
+ * rules where [hasBlock] is true so clients can determine matching token pairs.
+ */
+object X3RuleService {
+    data class Rule(
+        val token: String,
+        val hasBlock: Boolean,
+        val blockOpen: Boolean,
+        val blockClose: Boolean,
+        val blockMiddle: Boolean,
+        val blockPair: String?
+    )
+
+    private val rules: List<Rule> by lazy { loadRules() }
+
+    /**
+     * Returns all rules that represent block constructs in the language.
+     */
+    fun blockRules(): List<Rule> = rules.filter { it.hasBlock }
+
+    private fun loadRules(): List<Rule> {
+        val path = Paths.get("x3_language_rules.csv")
+        if (!Files.exists(path)) return emptyList()
+        return Files.newBufferedReader(path).useLines { lines ->
+            lines.drop(1).mapNotNull { line ->
+                // We only need the first 13 columns.
+                val parts = line.split(",", limit = 14)
+                if (parts.size < 13) return@mapNotNull null
+                Rule(
+                    token = parts[0].trim(),
+                    hasBlock = parts[8].trim().equals("true", ignoreCase = true),
+                    blockOpen = parts[9].trim().equals("true", ignoreCase = true),
+                    blockClose = parts[10].trim().equals("true", ignoreCase = true),
+                    blockMiddle = parts[11].trim().equals("true", ignoreCase = true),
+                    blockPair = parts[12].trim().ifEmpty { null }
+                )
+            }.toList()
+        }
+    }
+}
+

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/structure/NOX3BraceMatcher.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/structure/NOX3BraceMatcher.kt
@@ -1,0 +1,47 @@
+package com.enterscript.nox3languageplugin.language.structure
+
+import com.enterscript.nox3languageplugin.language.X3RuleService
+import com.enterscript.nox3languageplugin.language.psi.NOX3Types
+import com.intellij.lang.BracePair
+import com.intellij.lang.PairedBraceMatcher
+import com.intellij.psi.PsiFile
+import com.intellij.psi.tree.IElementType
+
+/**
+ * Provides brace matching for block constructs of the X3 language. Pairs are
+ * derived from [X3RuleService] using rules where `has_block` is `true` and
+ * `block_open` is `true`.
+ */
+class NOX3BraceMatcher : PairedBraceMatcher {
+
+    private val pairs: Array<BracePair>
+
+    init {
+        val list = mutableListOf<BracePair>()
+        for (rule in X3RuleService.blockRules().filter { it.blockOpen && !it.blockPair.isNullOrBlank() }) {
+            val open = findType(rule.token)
+            val close = findType(rule.blockPair!!)
+                ?: findType("END${rule.token}")
+            if (open != null && close != null) {
+                list += BracePair(open, close, true)
+            }
+        }
+        pairs = list.toTypedArray()
+    }
+
+    private fun findType(name: String): IElementType? {
+        return try {
+            val field = NOX3Types::class.java.getField(name)
+            field.get(null) as? IElementType
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    override fun getPairs(): Array<BracePair> = pairs
+
+    override fun isPairedBracesAllowedBeforeType(lbraceType: IElementType, contextType: IElementType?): Boolean = true
+
+    override fun getCodeConstructStart(file: PsiFile?, openingBraceOffset: Int): Int = openingBraceOffset
+}
+

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/structure/NOX3FoldingBuilder.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/structure/NOX3FoldingBuilder.kt
@@ -1,0 +1,70 @@
+package com.enterscript.nox3languageplugin.language.structure
+
+import com.enterscript.nox3languageplugin.language.X3RuleService
+import com.enterscript.nox3languageplugin.language.psi.NOX3Types
+import com.intellij.lang.ASTNode
+import com.intellij.lang.folding.FoldingBuilderEx
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.tree.IElementType
+
+/**
+ * Provides folding for blocks defined in the X3 language. Folding regions are
+ * determined from [X3RuleService] block information.
+ */
+class NOX3FoldingBuilder : FoldingBuilderEx() {
+
+    private val pairs: List<Pair<IElementType, IElementType>> =
+        X3RuleService.blockRules()
+            .filter { it.blockOpen && !it.blockPair.isNullOrBlank() }
+            .mapNotNull { rule ->
+                val open = findType(rule.token)
+                val close = findType(rule.blockPair!!) ?: findType("END${rule.token}")
+                if (open != null && close != null) open to close else null
+            }
+
+    private fun findType(name: String): IElementType? {
+        return try {
+            val field = NOX3Types::class.java.getField(name)
+            field.get(null) as? IElementType
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    override fun buildFoldRegions(root: ASTNode, document: Document): Array<FoldingDescriptor> {
+        val descriptors = mutableListOf<FoldingDescriptor>()
+        collectDescriptors(root, descriptors)
+        return descriptors.toTypedArray()
+    }
+
+    private fun collectDescriptors(node: ASTNode, descriptors: MutableList<FoldingDescriptor>) {
+        val pair = pairs.find { it.first == node.elementType }
+        if (pair != null) {
+            val end = findEndNode(node.treeNext, pair.second)
+            if (end != null && end.textRange.endOffset > node.startOffset) {
+                descriptors += FoldingDescriptor(node, TextRange(node.startOffset, end.textRange.endOffset))
+            }
+        }
+        var child = node.firstChildNode
+        while (child != null) {
+            collectDescriptors(child, descriptors)
+            child = child.treeNext
+        }
+    }
+
+    private fun findEndNode(start: ASTNode?, endType: IElementType): ASTNode? {
+        var current = start
+        while (current != null) {
+            if (current.elementType == endType) return current
+            current = current.treeNext
+        }
+        return null
+    }
+
+    override fun getPlaceholderText(node: ASTNode): String = "..."
+
+    override fun isCollapsedByDefault(node: ASTNode): Boolean = false
+}
+

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -45,6 +45,12 @@
         <lang.refactoringSupport
                 language="X3"
                 implementationClass="com.enterscript.nox3languageplugin.language.NOX3RefactoringSupportProvider"/>
+        <lang.braceMatcher
+                language="X3"
+                implementationClass="com.enterscript.nox3languageplugin.language.structure.NOX3BraceMatcher"/>
+        <lang.foldingBuilder
+                language="X3"
+                implementationClass="com.enterscript.nox3languageplugin.language.structure.NOX3FoldingBuilder"/>
         <codeInsight.lineMarkerProvider
                 language="JAVA"
                 implementationClass="com.enterscript.nox3languageplugin.language.NOX3LineMarkerProvider"/>


### PR DESCRIPTION
## Summary
- add X3RuleService to load block rules from CSV
- implement NOX3BraceMatcher using rule-based token pairs
- implement NOX3FoldingBuilder for block folding
- register brace matcher and folding builder in plugin.xml

## Testing
- `./gradlew test` *(fails: Could not resolve com.jetbrains.intellij.platform:test-framework... status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b76742fdfc83229c28f80f0875a5f5