### PR TITLE
Highlight deprecated or internal keywords with quick fixes

### DIFF
--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3Annotator.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3Annotator.kt
@@ -2,16 +2,37 @@ package com.enterscript.nox3languageplugin.language
 
 import com.intellij.lang.annotation.Annotator
 import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiLiteralExpression
+import com.intellij.psi.impl.source.tree.LeafPsiElement
+import com.enterscript.nox3languageplugin.language.psi.NOX3TokenType
+import com.enterscript.nox3languageplugin.language.ReplaceKeywordQuickFix
 
 /**
  * Provides simple annotation support for NOX3 string literals.
  */
 class NOX3Annotator : Annotator {
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {
-        // Placeholder annotator. Real highlighting will be implemented later.
-        if (element !is PsiLiteralExpression) return
+        if (element !is LeafPsiElement) return
+        if (element.elementType !is NOX3TokenType) return
+
+        val token = element.text.lowercase()
+        val info = X3RuleService.keywordInfo(token) ?: return
+
+        val (severity, message) = when (info.status) {
+            X3RuleService.KeywordStatus.Internal ->
+                HighlightSeverity.WARNING to "$token is internal"
+            X3RuleService.KeywordStatus.Deprecated,
+            X3RuleService.KeywordStatus.DeprecatedClassic ->
+                HighlightSeverity.WEAK_WARNING to "$token is deprecated"
+            else -> return
+        }
+
+        val builder = holder.newAnnotation(severity, message).range(element)
+        info.replacement?.let { replacement ->
+            builder.withFix(ReplaceKeywordQuickFix(element, replacement))
+        }
+        builder.create()
     }
 
     companion object {

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/ReplaceKeywordQuickFix.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/ReplaceKeywordQuickFix.kt
@@ -1,0 +1,38 @@
+package com.enterscript.nox3languageplugin.language
+
+import com.intellij.codeInsight.intention.IntentionAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiFile
+import com.intellij.psi.SmartPointerManager
+import com.intellij.psi.SmartPsiElementPointer
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiDocumentManager
+
+/**
+ * Quick fix replacing a deprecated or internal keyword with its suggested public equivalent.
+ */
+class ReplaceKeywordQuickFix(element: PsiElement, private val replacement: String) : IntentionAction {
+
+    private val elementPointer: SmartPsiElementPointer<PsiElement> =
+        SmartPointerManager.createPointer(element)
+
+    override fun getText(): String = "Replace with '$replacement'"
+
+    override fun getFamilyName(): String = "Replace with public keyword"
+
+    override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean {
+        return elementPointer.element != null
+    }
+
+    override fun startInWriteAction(): Boolean = true
+
+    override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
+        val element = elementPointer.element ?: return
+        val document = editor?.document ?: return
+        val range: TextRange = element.textRange
+        document.replaceString(range.startOffset, range.endOffset, replacement)
+        PsiDocumentManager.getInstance(project).commitDocument(document)
+    }
+}


### PR DESCRIPTION
## Summary
- Load keyword status and replacement info from CSV
- Annotate deprecated/internal keywords and offer replacements
- Add quick fix to swap tokens for public equivalents

## Testing
- `./gradlew test` *(fails: Could not resolve dependency com.jetbrains.intellij.platform:test-framework)*

------
https://chatgpt.com/codex/tasks/task_e_68b84eb6982c832291dad2386ef1901f