### PR TITLE
Add side-effect and arity inspections

### DIFF
--- a/src/main/kotlin/com/enterscript/nox3languageplugin/inspection/FunctionSideEffectInspection.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/inspection/FunctionSideEffectInspection.kt
@@ -1,0 +1,52 @@
+package com.enterscript.nox3languageplugin.inspection
+
+import com.enterscript.nox3languageplugin.language.NOX3Annotator
+import com.enterscript.nox3languageplugin.language.X3FunctionService
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.JavaElementVisitor
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiLiteralExpression
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.util.PsiTreeUtil
+
+/**
+ * Flags calls to side-effecting functions inside contexts annotated as pure.
+ * A very basic heuristic is used: the inspection looks for methods annotated with
+ * an annotation named `Pure` or `Contract` with `pure=true`.
+ */
+class FunctionSideEffectInspection : LocalInspectionTool() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object : JavaElementVisitor() {
+            override fun visitLiteralExpression(expression: PsiLiteralExpression) {
+                val value = expression.value as? String ?: return
+                val prefix = NOX3Annotator.NOX3_PREFIX_STR + NOX3Annotator.NOX3_SEPARATOR_STR
+                if (!value.startsWith(prefix)) return
+
+                val callPart = value.substring(prefix.length)
+                val name = callPart.substringBefore("(").trim()
+                if (name.isEmpty()) return
+
+                val info = X3FunctionService.functionInfo(name) ?: return
+                if (info.sideEffects != true) return
+                if (!isPureContext(expression)) return
+
+                holder.registerProblem(
+                    expression,
+                    "Call to side-effecting function '$name' in pure context"
+                )
+            }
+        }
+    }
+
+    private fun isPureContext(element: PsiElement): Boolean {
+        val method = PsiTreeUtil.getParentOfType(element, PsiMethod::class.java) ?: return false
+        val annotations = method.modifierList.annotations
+        return annotations.any { it.qualifiedName?.endsWith(".Pure") == true } ||
+            annotations.any {
+                it.qualifiedName == "org.jetbrains.annotations.Contract" &&
+                    it.findAttributeValue("pure")?.text == "true"
+            }
+    }
+}

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3Annotator.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3Annotator.kt
@@ -36,7 +36,8 @@ class NOX3Annotator : Annotator {
     }
 
     companion object {
-        const val NOX3_PREFIX_STR: String = "nox"
+        // Prefix used to identify NOX3 function calls inside string literals
+        const val NOX3_PREFIX_STR: String = "X3"
         const val NOX3_SEPARATOR_STR: String = ":"
     }
 }

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3FunctionCallInspection.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3FunctionCallInspection.kt
@@ -5,6 +5,11 @@ import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.JavaElementVisitor
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiLiteralExpression
+import com.enterscript.nox3languageplugin.language.X3FunctionService
+import java.util.regex.Pattern
+
+/** Regex to parse function calls like name(arg1,arg2) */
+private val CALL_PATTERN: Pattern = Pattern.compile("([A-Za-z_][A-Za-z0-9_]*)\\s*(?:\\((.*)\\))?")
 
 /**
  * Inspection that validates NOX3 function calls inside string literals.
@@ -19,13 +24,39 @@ class NOX3FunctionCallInspection : LocalInspectionTool() {
                 val prefix = NOX3Annotator.NOX3_PREFIX_STR + NOX3Annotator.NOX3_SEPARATOR_STR
                 if (!value.startsWith(prefix)) return
 
-                val references = expression.references.filterIsInstance<NOX3Reference>()
-                if (references.isEmpty()) return
+                val callPart = value.substring(prefix.length)
+                val matcher = CALL_PATTERN.matcher(callPart)
+                if (!matcher.matches()) return
+                val name = matcher.group(1)
+                val argsText = matcher.group(2) ?: ""
+                val argCount = if (argsText.isBlank()) 0 else argsText.split(',').size
 
-                val results = references.flatMap { it.multiResolve(false).toList() }
-                when {
-                    results.isEmpty() -> holder.registerProblem(expression, "Unresolved function call")
-                    results.size > 1 -> holder.registerProblem(expression, "Ambiguous function call")
+                val info = X3FunctionService.functionInfo(name)
+
+                val references = expression.references.filterIsInstance<NOX3Reference>()
+                if (references.isNotEmpty()) {
+                    val results = references.flatMap { it.multiResolve(false).toList() }
+                    when {
+                        results.isEmpty() -> holder.registerProblem(expression, "Unresolved function call")
+                        results.size > 1 -> holder.registerProblem(expression, "Ambiguous function call")
+                    }
+                }
+
+                info?.arityMin?.let { min ->
+                    if (argCount < min) {
+                        holder.registerProblem(
+                            expression,
+                            "Too few arguments for $name (minimum $min)"
+                        )
+                    }
+                }
+                info?.arityMax?.let { max ->
+                    if (argCount > max) {
+                        holder.registerProblem(
+                            expression,
+                            "Too many arguments for $name (maximum $max)"
+                        )
+                    }
                 }
             }
         }

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/X3FunctionService.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/X3FunctionService.kt
@@ -1,0 +1,40 @@
+package com.enterscript.nox3languageplugin.language
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+/**
+ * Service providing function metadata such as side effects and arity information.
+ */
+object X3FunctionService {
+    data class FunctionInfo(
+        val sideEffects: Boolean?,
+        val arityMin: Int?,
+        val arityMax: Int?
+    )
+
+    private val functions: Map<String, FunctionInfo> by lazy { loadFunctionInfos() }
+
+    fun functionInfo(name: String): FunctionInfo? = functions[name.uppercase()]
+
+    private fun loadFunctionInfos(): Map<String, FunctionInfo> {
+        val path = Paths.get("x3_language_rules.csv")
+        if (!Files.exists(path)) return emptyMap()
+        return Files.newBufferedReader(path).useLines { lines ->
+            lines.drop(1).mapNotNull { line ->
+                val parts = line.split(",", limit = 19)
+                if (parts.size < 18) return@mapNotNull null
+                val token = parts[0].trim()
+                val sideEffectsText = parts[14].trim()
+                val sideEffects = when {
+                    sideEffectsText.equals("YES", ignoreCase = true) -> true
+                    sideEffectsText.equals("NO", ignoreCase = true) -> false
+                    else -> null
+                }
+                val arityMin = parts.getOrNull(16)?.trim()?.toIntOrNull()
+                val arityMax = parts.getOrNull(17)?.trim()?.toIntOrNull()
+                token.uppercase() to FunctionInfo(sideEffects, arityMin, arityMax)
+            }.toMap()
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -63,6 +63,14 @@
                 enabledByDefault="true"
                 implementationClass="com.enterscript.nox3languageplugin.language.NOX3FunctionCallInspection"/>
 
+        <localInspection
+                language="JAVA"
+                shortName="NOX3FunctionSideEffect"
+                displayName="NOX3 side-effect function in pure context"
+                groupName="NOX3"
+                enabledByDefault="true"
+                implementationClass="com.enterscript.nox3languageplugin.inspection.FunctionSideEffectInspection"/>
+
     </extensions>
 
 </idea-plugin>

--- a/src/test/kotlin/com/enterscript/nox3languageplugin/inspection/FunctionSideEffectInspectionTest.kt
+++ b/src/test/kotlin/com/enterscript/nox3languageplugin/inspection/FunctionSideEffectInspectionTest.kt
@@ -1,0 +1,26 @@
+package com.enterscript.nox3languageplugin.inspection
+
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixture4TestCase
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class FunctionSideEffectInspectionTest : LightJavaCodeInsightFixture4TestCase() {
+
+    @Test
+    fun testSideEffectInPureContext() {
+        myFixture.configureByText("Pure.java", "public @interface Pure {}")
+        myFixture.configureByText(
+            "Foo.java",
+            """
+            class Foo {
+                @Pure void test() {
+                    String a = \"X3:ADXTCP()\";
+                }
+            }
+            """
+        )
+        myFixture.enableInspections(FunctionSideEffectInspection())
+        val highlights = myFixture.doHighlighting()
+        assertTrue(highlights.any { it.description?.contains("side-effecting function") == true })
+    }
+}

--- a/src/test/kotlin/com/enterscript/nox3languageplugin/language/NOX3FunctionCallInspectionTest.kt
+++ b/src/test/kotlin/com/enterscript/nox3languageplugin/language/NOX3FunctionCallInspectionTest.kt
@@ -8,19 +8,18 @@ import kotlin.test.assertTrue
 class NOX3FunctionCallInspectionTest : LightJavaCodeInsightFixture4TestCase() {
 
     @Test
-    fun testValidFunctionCall() {
-        myFixture.configureByText("a.src", "foo=bar")
-        myFixture.configureByText("Foo.java", "class Foo { String a = \"X3:foo\"; }")
+    fun testValidArity() {
+        myFixture.configureByText("Foo.java", "class Foo { String a = \"X3:addmonth(1,2)\"; }")
         myFixture.enableInspections(NOX3FunctionCallInspection())
         val highlights = myFixture.doHighlighting()
-        assertEquals(0, highlights.count { it.severity.myName == "ERROR" })
+        assertEquals(0, highlights.count { it.severity.myName == \"ERROR\" })
     }
 
     @Test
-    fun testInvalidFunctionCall() {
-        myFixture.configureByText("Foo.java", "class Foo { String a = \"X3:missing\"; }")
+    fun testInvalidArity() {
+        myFixture.configureByText("Foo.java", "class Foo { String a = \"X3:addmonth(1)\"; }")
         myFixture.enableInspections(NOX3FunctionCallInspection())
         val highlights = myFixture.doHighlighting()
-        assertTrue(highlights.any { it.description?.contains("Unresolved function call") == true })
+        assertTrue(highlights.any { it.description?.contains(\"Too few arguments\") == true })
     }
 }


### PR DESCRIPTION
## Summary
- add X3 function metadata loader for side effects and arity
- extend NOX3 function call inspection with argument count validation
- flag side-effecting function calls inside @Pure contexts

## Testing
- `./gradlew test` *(fails: Could not resolve com.jetbrains.intellij.platform:test-framework)*
