### PR TITLE
Use X3RuleService for keyword completion

### DIFF
--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3CompletionContributor.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3CompletionContributor.kt
@@ -2,8 +2,11 @@ package com.enterscript.nox3languageplugin.language
 
 import com.intellij.codeInsight.completion.*
 import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.icons.AllIcons
 import com.intellij.patterns.PlatformPatterns
+import com.intellij.psi.PsiManager
 import com.intellij.util.ProcessingContext
+import javax.swing.Icon
 
 /**
  * Provides basic code completion for the X3 language. Completions include
@@ -21,11 +24,24 @@ class NOX3CompletionContributor : CompletionContributor() {
                     context: ProcessingContext,
                     resultSet: CompletionResultSet
                 ) {
+                    val project = parameters.position.project
+
                     // glossary terms
-                    GLOSSARY.forEach { resultSet.addElement(LookupElementBuilder.create(it)) }
+                    X3RuleService.glossary()
+                        .sortedWith(compareBy({ STATUS_ORDER[it.status] }, { it.token }))
+                        .forEach { entry ->
+                            var builder = LookupElementBuilder
+                                .create(entry.token)
+                                .withIcon(iconFor(entry.family))
+                                .withTypeText(entry.family.name, true)
+                            if (entry.helpMd) {
+                                val docElement = NOX3KeywordDocElement(PsiManager.getInstance(project), entry.token)
+                                builder = builder.withPsiElement(docElement)
+                            }
+                            resultSet.addElement(builder)
+                        }
 
                     // project symbols (property keys)
-                    val project = parameters.position.project
                     NOX3Util.findProperties(project).mapNotNull { it.key }.forEach {
                         resultSet.addElement(LookupElementBuilder.create(it))
                     }
@@ -35,13 +51,20 @@ class NOX3CompletionContributor : CompletionContributor() {
     }
 
     private companion object {
-        val GLOSSARY = listOf(
-            // instructions
-            "if", "endif", "for", "to", "endfor", "else", "while", "case", "when", "endcase", "repeat", "until",
-            // system variables
-            "user", "sysdate",
-            // functions
-            "print()", "len()", "sqrt()"
+        private val STATUS_ORDER = mapOf(
+            X3RuleService.KeywordStatus.Public to 0,
+            X3RuleService.KeywordStatus.New to 1,
+            X3RuleService.KeywordStatus.Internal to 2,
+            X3RuleService.KeywordStatus.Deprecated to 3,
+            X3RuleService.KeywordStatus.DeprecatedClassic to 4,
+            X3RuleService.KeywordStatus.Unknown to 5
         )
+
+        private fun iconFor(family: X3RuleService.KeywordFamily): Icon = when (family) {
+            X3RuleService.KeywordFamily.FUNCTION -> AllIcons.Nodes.Function
+            X3RuleService.KeywordFamily.INSTRUCTION -> AllIcons.Nodes.Method
+            X3RuleService.KeywordFamily.SYSVAR -> AllIcons.Nodes.Variable
+            else -> AllIcons.Nodes.Property
+        }
     }
 }

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3DocumentationProvider.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3DocumentationProvider.kt
@@ -1,0 +1,26 @@
+package com.enterscript.nox3languageplugin.language
+
+import com.intellij.lang.documentation.DocumentationProvider
+import com.intellij.psi.PsiElement
+import com.intellij.psi.impl.source.tree.LeafPsiElement
+
+/**
+ * Documentation provider that reads markdown help files for X3 keywords.
+ */
+class NOX3DocumentationProvider : DocumentationProvider {
+    override fun generateDoc(element: PsiElement, originalElement: PsiElement?): String? {
+        val keyword = when (element) {
+            is NOX3KeywordDocElement -> element.keyword
+            is LeafPsiElement -> element.text
+            else -> return null
+        }?.lowercase() ?: return null
+
+        val rule = X3RuleService.ruleFor(keyword) ?: return null
+        if (!rule.helpMd) return null
+
+        val resource = "docs/$keyword.md"
+        val stream = this::class.java.classLoader.getResourceAsStream(resource) ?: return null
+        return stream.bufferedReader().use { it.readText() }
+    }
+}
+

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3KeywordDocElement.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3KeywordDocElement.kt
@@ -1,0 +1,16 @@
+package com.enterscript.nox3languageplugin.language
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiManager
+import com.intellij.psi.impl.FakePsiElement
+
+/**
+ * Lightweight PSI element used to attach documentation to lookup items.
+ */
+class NOX3KeywordDocElement(private val manager: PsiManager, val keyword: String) : FakePsiElement() {
+    override fun getProject() = manager.project
+    override fun getLanguage() = NOX3Language.INSTANCE
+    override fun getParent(): PsiElement? = null
+    override fun toString(): String = "NOX3KeywordDocElement($keyword)"
+}
+

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -40,6 +40,9 @@
         <completion.contributor
                 language="X3"
                 implementationClass="com.enterscript.nox3languageplugin.language.NOX3CompletionContributor"/>
+        <lang.documentationProvider
+                language="X3"
+                implementationClass="com.enterscript.nox3languageplugin.language.NOX3DocumentationProvider"/>
         <psi.referenceContributor
                 implementation="com.enterscript.nox3languageplugin.language.NOX3ReferenceContributor"/>
         <lang.refactoringSupport


### PR DESCRIPTION
## Summary
- derive completion keywords from X3RuleService with family-aware icons
- sort suggestions by keyword status and attach markdown docs when available
- register a documentation provider for keyword help files

## Testing
- `./gradlew build` *(fails: Could not resolve com.jetbrains.intellij.platform:test-framework due to 403 Forbidden)*
