### PR TITLE
Fix gradle configuration and build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ Thanks for your contributions!
 
 <!-- Plugin description end -->
 
+## Build
+
+This project requires **JDK 17 or newer**. The Gradle wrapper is configured for
+Gradle 8.14 and will download it automatically. To compile and run the tests
+locally:
+
+```bash
+./gradlew build
+```
+
+The produced plugin distribution is available under `build/distributions`.
+
 ## Contributing
 
 Before contributing, please read the [CONTRIBUTING](CONTRIBUTING.md) guide and our [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md).

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,11 +9,11 @@ pluginVersion = 0.0.2
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 251
+pluginSinceBuild = 242
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 2025.1.5
+platformVersion = 2024.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
@@ -25,7 +25,7 @@ platformBundledModules =
 javaVersion = 21
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 9.0.0
+gradleVersion = 8.14
 
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ changelog = "2.4.0"
 intelliJPlatform = "2.7.2"
 kotlin = "2.2.0"
 kover = "0.9.1"
-qodana = "2025.1.1"
+qodana = "2024.2.2"
 grammarkit = "2022.3.2.2"
 
 [libraries]


### PR DESCRIPTION
## Summary
- target stable IntelliJ Platform 2024.1 and Gradle 8.14
- update Qodana plugin version
- document build requirements and steps

## Testing
- `./gradlew --no-daemon --console=plain build` *(fails: No IntelliJ Platform dependency found with 'IC-2024.1 (installer)' )*
