### PR TITLE
build: target Java 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 21
+          java-version: 17
 
       # Setup Gradle
       - name: Setup Gradle
@@ -99,7 +99,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 21
+          java-version: 17
 
       # Setup Gradle
       - name: Setup Gradle
@@ -156,7 +156,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 21
+          java-version: 17
 
       # Run Qodana inspections
       - name: Qodana - Code Inspection
@@ -187,7 +187,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 21
+          java-version: 17
 
       # Setup Gradle
       - name: Setup Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 21
+          java-version: 17
 
       # Setup Gradle
       - name: Setup Gradle

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 21
+          java-version: 17
 
       # Setup Gradle
       - name: Setup Gradle

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing to this project!
 
 ## Build
 
-This project uses the Gradle build system and requires JDK 21.
+This project uses the Gradle build system and requires JDK 17.
 
 To build the plugin run:
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,8 @@ Thanks for your contributions!
 
 ## Build
 
-This project requires **JDK 17 or newer**. The Gradle wrapper is configured for
-Gradle 8.14 and will download it automatically. To compile and run the tests
-locally:
+This project requires **JDK 17**. The Gradle wrapper is configured for Gradle
+8.14 and will download it automatically. To compile and run the tests locally:
 
 ```bash
 ./gradlew build

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ group = properties("pluginGroup")
 version = properties("pluginVersion")
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(17)
 }
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ platformBundledPlugins =
 platformBundledModules =
 
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
-javaVersion = 21
+javaVersion = 17
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 8.14


### PR DESCRIPTION
## Summary
- use Java 17 toolchain and properties
- run all GitHub workflows on Java 17
- document Java 17 requirement for building

## Testing
- `./gradlew test` *(fails: Unresolved reference: intellijPlatform)*
