### PR TITLE
Include generated sources directory in build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 .idea
 .intellijPlatform/
 build/
-build/gen/
 buildSrc/build/
+
+# Generated sources
+build/gen/
 /src/test/kotlin/com/enterscript/noX3LanguagePlugin/MyPluginTest.kt
 /src/main/code_samples/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,12 @@ dependencies {
     }
 }
 
-sourceSets["main"].kotlin.srcDir("build/gen")
+sourceSets {
+    main {
+        java.srcDir(layout.buildDirectory.dir("gen"))
+        kotlin.srcDir("build/gen")
+    }
+}
 
 val generateNox3Lexer by tasks.registering(GenerateLexer::class) {
     sourceFile.set(file("src/main/grammars/NOX3.flex"))


### PR DESCRIPTION
## Summary
- Add generated Java directory to `main` source set
- Note generated sources in `.gitignore`

## Testing
- `./gradlew test` *(fails: Unresolved reference: intellijPlatform)*
