### PR TITLE
Add repository mode to dependency resolution management

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.intellij.platform.gradle.extensions.IntelliJPlatformRepositoriesExtension
 import org.jetbrains.intellij.platform.gradle.extensions.intellijPlatform
+import org.gradle.api.initialization.resolve.RepositoriesMode
 
 IntelliJPlatformRepositoriesExtension.register(settings, settings.pluginManagement.repositories)
 
@@ -14,6 +15,7 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         mavenCentral()
         intellijPlatform {


### PR DESCRIPTION
## Summary
- enforce `RepositoriesMode.FAIL_ON_PROJECT_REPOS` in `dependencyResolutionManagement`

## Testing
- `./gradlew test` *(fails: Unresolved reference: intellijPlatform)*

------
https://chatgpt.com/codex/tasks/task_e_68b901754e748322a8039cf8b70dacc9