### PR TITLE
feat: expand color settings descriptors

### DIFF
--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3ColorSettingsPage.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3ColorSettingsPage.kt
@@ -13,6 +13,10 @@ class NOX3ColorSettingsPage : ColorSettingsPage {
     companion object {
         private val DESCRIPTORS = arrayOf(
             AttributesDescriptor("Keyword", NOX3SyntaxHighlighter.KEYWORD),
+            AttributesDescriptor("String", NOX3SyntaxHighlighter.STRING),
+            AttributesDescriptor("Number", NOX3SyntaxHighlighter.NUMBER),
+            AttributesDescriptor("Comment", NOX3SyntaxHighlighter.COMMENT),
+            AttributesDescriptor("Separator", NOX3SyntaxHighlighter.SEPARATOR),
             AttributesDescriptor("Identifier", NOX3SyntaxHighlighter.IDENTIFIER),
             AttributesDescriptor("Bad value", NOX3SyntaxHighlighter.BAD_CHARACTER)
         )
@@ -23,6 +27,14 @@ class NOX3ColorSettingsPage : ColorSettingsPage {
     override fun getDisplayName(): String = "X3"
     override fun getIcon(): Icon? = NOX3Icons.Icon.FileType
     override fun getHighlighter(): SyntaxHighlighter = NOX3SyntaxHighlighter()
-    override fun getDemoText(): String = "module Demo\nfunction foo\nvar bar"
+    override fun getDemoText(): String = """
+        module Demo
+        function greet:demo
+            var message = "hello"
+            var count = 42
+            if count = 42
+                # sample comment
+            endif
+        """.trimIndent()
     override fun getAdditionalHighlightingTagToDescriptorMap(): MutableMap<String, TextAttributesKey>? = null
 }

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/syntax/NOX3SyntaxHighlighter.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/syntax/NOX3SyntaxHighlighter.kt
@@ -20,9 +20,11 @@ class NOX3SyntaxHighlighter : SyntaxHighlighterBase() {
     companion object {
         val KEYWORD: TextAttributesKey = createTextAttributesKey("NOX3_KEYWORD", DefaultLanguageHighlighterColors.KEYWORD)
         val STRING: TextAttributesKey = createTextAttributesKey("NOX3_STRING", DefaultLanguageHighlighterColors.STRING)
+        val NUMBER: TextAttributesKey = createTextAttributesKey("NOX3_NUMBER", DefaultLanguageHighlighterColors.NUMBER)
         val COMMENT: TextAttributesKey = createTextAttributesKey("NOX3_COMMENT", DefaultLanguageHighlighterColors.LINE_COMMENT)
         val BAD_CHARACTER: TextAttributesKey = createTextAttributesKey("NOX3_BAD_CHARACTER", HighlighterColors.BAD_CHARACTER)
-        private val SEPARATOR: TextAttributesKey = createTextAttributesKey("NOX3_SEPARATOR", DefaultLanguageHighlighterColors.OPERATION_SIGN)
+        val SEPARATOR: TextAttributesKey = createTextAttributesKey("NOX3_SEPARATOR", DefaultLanguageHighlighterColors.OPERATION_SIGN)
+        val IDENTIFIER: TextAttributesKey = createTextAttributesKey("NOX3_IDENTIFIER", DefaultLanguageHighlighterColors.IDENTIFIER)
 
         private val keys = HashMap<IElementType, TextAttributesKey>().apply {
             listOf(
@@ -32,6 +34,8 @@ class NOX3SyntaxHighlighter : SyntaxHighlighterBase() {
                 NOX3Types.USER, NOX3Types.SYSDATE
             ).forEach { put(it, KEYWORD) }
             put(NOX3Types.STRING, STRING)
+            put(NOX3Types.NUMBER, NUMBER)
+            put(NOX3Types.IDENTIFIER, IDENTIFIER)
             put(NOX3Types.COMMENT, COMMENT)
             put(NOX3Types.SEPARATOR, SEPARATOR)
             put(TokenType.BAD_CHARACTER, BAD_CHARACTER)


### PR DESCRIPTION
## Summary
- expose number, identifier and separator attribute keys in syntax highlighter
- broaden color settings descriptors to cover strings, numbers, comments, separators and identifiers
- provide richer demo snippet showcasing language constructs

## Testing
- `./gradlew -q build` *(fails: Unresolved reference: intellijPlatform)*
