### PR TITLE
feat: index variables and properties with stubs

### DIFF
--- a/src/main/grammars/NOX3.bnf
+++ b/src/main/grammars/NOX3.bnf
@@ -607,8 +607,10 @@ function_decl ::= FUNCTION IDENTIFIER element_* END {
 
 variable_decl ::= (VAR | VARIABLE) IDENTIFIER (SEPARATOR expression)? {
     pin=2
+    stubClass="com.enterscript.nox3languageplugin.language.psi.stubs.NOX3VariableStub"
+    elementTypeClass="com.enterscript.nox3languageplugin.language.psi.stubs.NOX3VariableStubElementType"
     mixin="com.enterscript.nox3languageplugin.language.psi.impl.NOX3NamedElementImpl"
-    implements="com.enterscript.nox3languageplugin.language.psi.NOX3Variable"
+    implements="com.enterscript.nox3languageplugin.language.psi.NOX3Variable, com.intellij.psi.stubs.StubBasedPsiElement<com.enterscript.nox3languageplugin.language.psi.stubs.NOX3VariableStub>"
     methods=[getName setName getNameIdentifier]
 }
 
@@ -616,8 +618,10 @@ private module_decl_recover ::= !(END)
 private function_decl_recover ::= !(END)
 
 property ::= IDENTIFIER SEPARATOR value {
+    stubClass="com.enterscript.nox3languageplugin.language.psi.stubs.NOX3PropertyStub"
+    elementTypeClass="com.enterscript.nox3languageplugin.language.psi.stubs.NOX3PropertyStubElementType"
     mixin="com.enterscript.nox3languageplugin.language.psi.impl.NOX3NamedElementImpl"
-    implements="com.enterscript.nox3languageplugin.language.psi.NOX3Property"
+    implements="com.enterscript.nox3languageplugin.language.psi.NOX3Property, com.intellij.psi.stubs.StubBasedPsiElement<com.enterscript.nox3languageplugin.language.psi.stubs.NOX3PropertyStub>"
     methods=[getKey getValue getName setName getNameIdentifier]
 }
 

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3Util.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3Util.kt
@@ -1,33 +1,51 @@
 package com.enterscript.nox3languageplugin.language
 
-import com.enterscript.nox3languageplugin.language.psi.NOX3File
+import com.enterscript.nox3languageplugin.language.psi.NOX3Property
 import com.enterscript.nox3languageplugin.language.psi.NOX3Variable
+import com.enterscript.nox3languageplugin.language.psi.stubs.NOX3PropertyStubElementType
+import com.enterscript.nox3languageplugin.language.psi.stubs.NOX3VariableStubElementType
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiManager
-import com.intellij.psi.search.FileTypeIndex
 import com.intellij.psi.search.GlobalSearchScope
-import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.stubs.StubIndex
 
 open class NOX3Util {
     companion object {
-        fun findVariables(project: Project, name: String): List<NOX3Variable> {
+        fun findVariables(project: Project, name: String): Collection<NOX3Variable> =
+            StubIndex.getElements(
+                NOX3VariableStubElementType.INDEX_KEY,
+                name,
+                project,
+                GlobalSearchScope.allScope(project),
+                NOX3Variable::class.java
+            )
+
+        fun findVariables(project: Project): Collection<NOX3Variable> {
+            val index = StubIndex.getInstance()
+            val scope = GlobalSearchScope.allScope(project)
+            val key = NOX3VariableStubElementType.INDEX_KEY
             val result = mutableListOf<NOX3Variable>()
-            val virtualFiles = FileTypeIndex.getFiles(NOX3FileType.INSTANCE, GlobalSearchScope.allScope(project))
-            for (virtualFile in virtualFiles) {
-                val file = PsiManager.getInstance(project).findFile(virtualFile) as? NOX3File ?: continue
-                val variables = PsiTreeUtil.findChildrenOfType(file, NOX3Variable::class.java)
-                variables.filterTo(result) { it.name == name }
+            for (variableName in index.getAllKeys(key, project)) {
+                result.addAll(index.getElements(key, variableName, project, scope, NOX3Variable::class.java))
             }
             return result
         }
 
-        fun findVariables(project: Project): List<NOX3Variable> {
-            val result = mutableListOf<NOX3Variable>()
-            val virtualFiles = FileTypeIndex.getFiles(NOX3FileType.INSTANCE, GlobalSearchScope.allScope(project))
-            for (virtualFile in virtualFiles) {
-                val file = PsiManager.getInstance(project).findFile(virtualFile) as? NOX3File ?: continue
-                val variables = PsiTreeUtil.findChildrenOfType(file, NOX3Variable::class.java)
-                result.addAll(variables)
+        fun findProperties(project: Project, name: String): Collection<NOX3Property> =
+            StubIndex.getElements(
+                NOX3PropertyStubElementType.INDEX_KEY,
+                name,
+                project,
+                GlobalSearchScope.allScope(project),
+                NOX3Property::class.java
+            )
+
+        fun findProperties(project: Project): Collection<NOX3Property> {
+            val index = StubIndex.getInstance()
+            val scope = GlobalSearchScope.allScope(project)
+            val key = NOX3PropertyStubElementType.INDEX_KEY
+            val result = mutableListOf<NOX3Property>()
+            for (propertyName in index.getAllKeys(key, project)) {
+                result.addAll(index.getElements(key, propertyName, project, scope, NOX3Property::class.java))
             }
             return result
         }

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/NOX3Property.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/NOX3Property.kt
@@ -1,6 +1,9 @@
 package com.enterscript.nox3languageplugin.language.psi
 
-interface NOX3Property : NOX3NamedElement {
+import com.enterscript.nox3languageplugin.language.psi.stubs.NOX3PropertyStub
+import com.intellij.psi.stubs.StubBasedPsiElement
+
+interface NOX3Property : NOX3NamedElement, StubBasedPsiElement<NOX3PropertyStub> {
     fun getKey(): String?
     fun getValue(): String?
 }

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/NOX3Variable.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/NOX3Variable.kt
@@ -1,3 +1,6 @@
 package com.enterscript.nox3languageplugin.language.psi
 
-interface NOX3Variable : NOX3NamedElement
+import com.enterscript.nox3languageplugin.language.psi.stubs.NOX3VariableStub
+import com.intellij.psi.stubs.StubBasedPsiElement
+
+interface NOX3Variable : NOX3NamedElement, StubBasedPsiElement<NOX3VariableStub>

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/stubs/NOX3PropertyStub.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/stubs/NOX3PropertyStub.kt
@@ -1,0 +1,8 @@
+package com.enterscript.nox3languageplugin.language.psi.stubs
+
+import com.enterscript.nox3languageplugin.language.psi.NOX3Property
+import com.intellij.psi.stubs.StubElement
+
+interface NOX3PropertyStub : StubElement<NOX3Property> {
+    val name: String?
+}

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/stubs/NOX3PropertyStubElementType.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/stubs/NOX3PropertyStubElementType.kt
@@ -1,0 +1,34 @@
+package com.enterscript.nox3languageplugin.language.psi.stubs
+
+import com.enterscript.nox3languageplugin.language.NOX3Language
+import com.enterscript.nox3languageplugin.language.psi.NOX3Property
+import com.enterscript.nox3languageplugin.language.psi.impl.NOX3PropertyImpl
+import com.intellij.psi.stubs.*
+
+class NOX3PropertyStubElementType(debugName: String) :
+    IStubElementType<NOX3PropertyStub, NOX3Property>(debugName, NOX3Language.INSTANCE) {
+
+    override fun createPsi(stub: NOX3PropertyStub): NOX3Property =
+        NOX3PropertyImpl(stub, this)
+
+    override fun createStub(psi: NOX3Property, parentStub: StubElement<*>?): NOX3PropertyStub =
+        NOX3PropertyStubImpl(parentStub, this, psi.name)
+
+    override fun serialize(stub: NOX3PropertyStub, dataStream: StubOutputStream) {
+        dataStream.writeName(stub.name)
+    }
+
+    override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?): NOX3PropertyStub =
+        NOX3PropertyStubImpl(parentStub, this, dataStream.readNameString())
+
+    override fun indexStub(stub: NOX3PropertyStub, sink: IndexSink) {
+        stub.name?.let { sink.occurrence(INDEX_KEY, it) }
+    }
+
+    override fun getExternalId(): String = "nox3.property"
+
+    companion object {
+        val INDEX_KEY: StubIndexKey<String, NOX3Property> =
+            StubIndexKey.createIndexKey("nox3.property")
+    }
+}

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/stubs/NOX3PropertyStubImpl.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/stubs/NOX3PropertyStubImpl.kt
@@ -1,0 +1,12 @@
+package com.enterscript.nox3languageplugin.language.psi.stubs
+
+import com.enterscript.nox3languageplugin.language.psi.NOX3Property
+import com.intellij.psi.stubs.IStubElementType
+import com.intellij.psi.stubs.StubBase
+import com.intellij.psi.stubs.StubElement
+
+class NOX3PropertyStubImpl(
+    parent: StubElement<*>?,
+    elementType: IStubElementType<*, *>,
+    override val name: String?
+) : StubBase<NOX3Property>(parent, elementType), NOX3PropertyStub

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/stubs/NOX3VariableStub.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/stubs/NOX3VariableStub.kt
@@ -1,0 +1,8 @@
+package com.enterscript.nox3languageplugin.language.psi.stubs
+
+import com.enterscript.nox3languageplugin.language.psi.NOX3Variable
+import com.intellij.psi.stubs.StubElement
+
+interface NOX3VariableStub : StubElement<NOX3Variable> {
+    val name: String?
+}

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/stubs/NOX3VariableStubElementType.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/stubs/NOX3VariableStubElementType.kt
@@ -1,0 +1,34 @@
+package com.enterscript.nox3languageplugin.language.psi.stubs
+
+import com.enterscript.nox3languageplugin.language.NOX3Language
+import com.enterscript.nox3languageplugin.language.psi.NOX3Variable
+import com.enterscript.nox3languageplugin.language.psi.impl.NOX3VariableImpl
+import com.intellij.psi.stubs.*
+
+class NOX3VariableStubElementType(debugName: String) :
+    IStubElementType<NOX3VariableStub, NOX3Variable>(debugName, NOX3Language.INSTANCE) {
+
+    override fun createPsi(stub: NOX3VariableStub): NOX3Variable =
+        NOX3VariableImpl(stub, this)
+
+    override fun createStub(psi: NOX3Variable, parentStub: StubElement<*>?): NOX3VariableStub =
+        NOX3VariableStubImpl(parentStub, this, psi.name)
+
+    override fun serialize(stub: NOX3VariableStub, dataStream: StubOutputStream) {
+        dataStream.writeName(stub.name)
+    }
+
+    override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?): NOX3VariableStub =
+        NOX3VariableStubImpl(parentStub, this, dataStream.readNameString())
+
+    override fun indexStub(stub: NOX3VariableStub, sink: IndexSink) {
+        stub.name?.let { sink.occurrence(INDEX_KEY, it) }
+    }
+
+    override fun getExternalId(): String = "nox3.variable"
+
+    companion object {
+        val INDEX_KEY: StubIndexKey<String, NOX3Variable> =
+            StubIndexKey.createIndexKey("nox3.variable")
+    }
+}

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/stubs/NOX3VariableStubImpl.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/stubs/NOX3VariableStubImpl.kt
@@ -1,0 +1,12 @@
+package com.enterscript.nox3languageplugin.language.psi.stubs
+
+import com.enterscript.nox3languageplugin.language.psi.NOX3Variable
+import com.intellij.psi.stubs.IStubElementType
+import com.intellij.psi.stubs.StubBase
+import com.intellij.psi.stubs.StubElement
+
+class NOX3VariableStubImpl(
+    parent: StubElement<*>?,
+    elementType: IStubElementType<*, *>,
+    override val name: String?
+) : StubBase<NOX3Variable>(parent, elementType), NOX3VariableStub


### PR DESCRIPTION
## Summary
- add stub-based PSI definitions for variables and properties
- index variables and properties via custom stub element types
- query stub indices in NOX3Util instead of scanning files

## Testing
- `./gradlew test` *(fails: Unresolved reference: intellijPlatform)*


