### PR TITLE
Add parsing test for module, function, and variable

### DIFF
--- a/src/test/kotlin/com/enterscript/nox3languageplugin/language/NOX3ParsingTest.kt
+++ b/src/test/kotlin/com/enterscript/nox3languageplugin/language/NOX3ParsingTest.kt
@@ -1,0 +1,15 @@
+package com.enterscript.nox3languageplugin.language
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.psi.util.PsiTreeUtil
+import kotlin.test.assertFalse
+
+class NOX3ParsingTest : BasePlatformTestCase() {
+    fun testModuleFunctionVariableParsing() {
+        val file = myFixture.configureByText(
+            "test.nox3",
+            """module Demo\nfunction foo\nend\nvar bar\nend"""
+        )
+        assertFalse(PsiTreeUtil.hasErrorElements(file))
+    }
+}


### PR DESCRIPTION
## Summary
- add parsing test to ensure modules with functions and variables parse without errors

## Testing
- `./gradlew test` *(fails: Unresolved reference: intellijPlatform)*

------
https://chatgpt.com/codex/tasks/task_e_68b935acfb148322977fb7e53c9ad3c3