### PR TITLE
chore: register platform repository extension for resolution

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.intellij.platform.gradle.extensions.intellijPlatform
 import org.gradle.api.initialization.resolve.RepositoriesMode
 
 IntelliJPlatformRepositoriesExtension.register(settings, settings.pluginManagement.repositories)
+IntelliJPlatformRepositoriesExtension.register(settings, settings.dependencyResolutionManagement.repositories)
 
 pluginManagement {
     repositories {


### PR DESCRIPTION
## Summary
- register IntelliJ Platform repositories extension for dependency resolution

## Testing
- `./gradlew clean build --no-configuration-cache` *(fails: Unresolved reference: intellijPlatform)*

------
https://chatgpt.com/codex/tasks/task_e_68b99305d4788322b8cf51060f2d57d8