### PR TITLE
Configure IntelliJ Platform build settings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.jetbrains.changelog.Changelog
-import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.grammarkit.tasks.GenerateLexer
 import org.jetbrains.grammarkit.tasks.GenerateParser
 
@@ -8,7 +7,7 @@ fun properties(key: String) = project.findProperty(key).toString()
 plugins {
     id("java")
     alias(libs.plugins.kotlin)
-    alias(libs.plugins.intelliJPlatform)
+    id("org.jetbrains.intellij.platform")
     alias(libs.plugins.changelog)
     alias(libs.plugins.qodana)
     alias(libs.plugins.kover)
@@ -32,25 +31,9 @@ repositories {
 dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.opentest4j)
-
     intellijPlatform {
-        create(properties("platformType"), properties("platformVersion"))
-        plugins(
-            providers.gradleProperty("platformPlugins").map {
-                it.split(',').map(String::trim).filter(String::isNotEmpty)
-            }
-        )
-        bundledPlugins(
-            providers.gradleProperty("platformBundledPlugins").map {
-                it.split(',').map(String::trim).filter(String::isNotEmpty)
-            }
-        )
-        bundledModules(
-            providers.gradleProperty("platformBundledModules").map {
-                it.split(',').map(String::trim).filter(String::isNotEmpty)
-            }
-        )
-        testFramework(TestFrameworkType.Platform)
+        create(type = properties("platformType"), version = properties("platformVersion"))
+        intellijPlugin(properties("platformPlugins"))
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,7 @@ IntelliJPlatformRepositoriesExtension.register(settings, settings.dependencyReso
 pluginManagement {
     repositories {
         mavenCentral()
+        gradlePluginPortal()
         intellijPlatform {
             releases()
             marketplace()
@@ -19,6 +20,7 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         mavenCentral()
+        gradlePluginPortal()
         intellijPlatform {
             releases()
             marketplace()


### PR DESCRIPTION
## Summary
- add Gradle plugin and dependency resolution repositories for IntelliJ Platform
- migrate build script to `org.jetbrains.intellij.platform` plugin and simplified dependencies

## Testing
- `./gradlew test` *(fails: Unresolved reference intellijPlatform in settings.gradle.kts)*
