### PR TITLE
Add equals operator token to lexer

### DIFF
--- a/src/main/grammars/NOX3.flex
+++ b/src/main/grammars/NOX3.flex
@@ -45,6 +45,7 @@ DECIMAL=(?i:Decimal)
 INTEGER=(?i:Integer)
 DATE=(?i:Date)
 
+EQUAL==
 PLUS=\+
 MINUS=-
 LPAREN=\(
@@ -81,7 +82,7 @@ COLON=:
 {INTEGER}     { return NOX3Types.INTEGER; }
 {DATE}        { return NOX3Types.DATE; }
 
-"="           { return NOX3Types.SEPARATOR; }
+{EQUAL}       { return NOX3Types.SEPARATOR; }
 {PLUS}        { return NOX3Types.PLUS; }
 {MINUS}       { return NOX3Types.MINUS; }
 {LPAREN}      { return NOX3Types.LPAREN; }


### PR DESCRIPTION
## Summary
- define an `EQUAL` macro for `=` and wire it to `NOX3Types.SEPARATOR`

## Testing
- `./gradlew test` *(fails: Unresolved reference: intellijPlatform)*


