### PR TITLE
Remove obsolete manual PSI interfaces

### DIFF
--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/NOX3Function.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/NOX3Function.kt
@@ -1,3 +1,0 @@
-package com.enterscript.nox3languageplugin.language.psi
-
-interface NOX3Function : NOX3NamedElement

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/NOX3Module.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/NOX3Module.kt
@@ -1,3 +1,0 @@
-package com.enterscript.nox3languageplugin.language.psi
-
-interface NOX3Module : NOX3NamedElement

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/NOX3Variable.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/NOX3Variable.kt
@@ -1,6 +1,0 @@
-package com.enterscript.nox3languageplugin.language.psi
-
-import com.enterscript.nox3languageplugin.language.psi.stubs.NOX3VariableStub
-import com.intellij.psi.stubs.StubBasedPsiElement
-
-interface NOX3Variable : NOX3NamedElement, StubBasedPsiElement<NOX3VariableStub>


### PR DESCRIPTION
## Summary
- remove legacy manual `NOX3Module`, `NOX3Function`, and `NOX3Variable` interfaces
- confirm plugin configuration contains no references to removed PSI classes

## Testing
- `./gradlew test` *(fails: Unresolved reference: intellijPlatform)*

