### PR TITLE
Use internal lexer instantiation

### DIFF
--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/parser/NOX3ParserDefinition.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/parser/NOX3ParserDefinition.kt
@@ -8,10 +8,8 @@ import com.enterscript.nox3languageplugin.language.psi.NOX3File
 import com.enterscript.nox3languageplugin.language.psi.NOX3Types
 import com.intellij.lang.ASTNode
 import com.intellij.lang.ParserDefinition
-import com.intellij.lang.PsiParser
 import com.intellij.openapi.project.Project
 import com.intellij.psi.FileViewProvider
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.TokenType
 import com.intellij.psi.tree.IFileElementType
@@ -24,13 +22,13 @@ class NOX3ParserDefinition : ParserDefinition {
         val FILE: IFileElementType = IFileElementType(NOX3Language.INSTANCE)
     }
 
-    override fun createLexer(project: Project) = NOX3LexerAdapter(_NOX3Lexer(null))
+    override fun createLexer(project: Project) = NOX3LexerAdapter()
     override fun getWhitespaceTokens(): TokenSet = WHITE_SPACES
     override fun getCommentTokens(): TokenSet = COMMENTS
     override fun getStringLiteralElements(): TokenSet = TokenSet.EMPTY
-    override fun createParser(project: Project): PsiParser = NOX3Parser()
     override fun getFileNodeType(): IFileElementType = FILE
     override fun createFile(viewProvider: FileViewProvider): PsiFile = NOX3File(viewProvider)
     override fun spaceExistanceTypeBetweenTokens(first: ASTNode, second: ASTNode) = ParserDefinition.SpaceRequirements.MAY
-    override fun createElement(node: ASTNode): PsiElement = NOX3Types.Factory.createElement(node)
+    override fun createParser(project: Project) = NOX3Parser()
+    override fun createElement(node: ASTNode) = NOX3Types.Factory.createElement(node)
 }


### PR DESCRIPTION
## Summary
- Instantiate the parser definition's lexer via `NOX3LexerAdapter` without manual `_NOX3Lexer` wiring.
- Implement parser and PSI element creation with direct calls to `NOX3Parser` and `NOX3Types` factories.

## Testing
- `./gradlew test` *(fails: Unresolved reference intellijPlatform in settings.gradle.kts)*
