### PR TITLE
feat: expand Sage X3 syntax highlighting

### DIFF
--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3ColorSettingsPage.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3ColorSettingsPage.kt
@@ -13,11 +13,11 @@ class NOX3ColorSettingsPage : ColorSettingsPage {
     companion object {
         private val DESCRIPTORS = arrayOf(
             AttributesDescriptor("Keyword", NOX3SyntaxHighlighter.KEYWORD),
-            AttributesDescriptor("String", NOX3SyntaxHighlighter.STRING),
-            AttributesDescriptor("Number", NOX3SyntaxHighlighter.NUMBER),
-            AttributesDescriptor("Comment", NOX3SyntaxHighlighter.COMMENT),
-            AttributesDescriptor("Separator", NOX3SyntaxHighlighter.SEPARATOR),
             AttributesDescriptor("Identifier", NOX3SyntaxHighlighter.IDENTIFIER),
+            AttributesDescriptor("Number", NOX3SyntaxHighlighter.NUMBER),
+            AttributesDescriptor("String", NOX3SyntaxHighlighter.STRING),
+            AttributesDescriptor("Comment", NOX3SyntaxHighlighter.COMMENT),
+            AttributesDescriptor("Operator", NOX3SyntaxHighlighter.OPERATOR),
             AttributesDescriptor("Bad value", NOX3SyntaxHighlighter.BAD_CHARACTER)
         )
     }
@@ -28,13 +28,19 @@ class NOX3ColorSettingsPage : ColorSettingsPage {
     override fun getIcon(): Icon? = NOX3Icons.Icon.FileType
     override fun getHighlighter(): SyntaxHighlighter = NOX3SyntaxHighlighter()
     override fun getDemoText(): String = """
-        module Demo
-        function greet:demo
-            var message = "hello"
-            var count = 42
-            if count = 42
-                # sample comment
-            endif
+        Subprog DEMO()
+        Global Integer gVar
+        Local Char(10) msg
+        Local Integer i
+        Class MYCLASS()
+
+        If gVar = 0
+          For i = 1 To 3
+            msg = msg + "Hi" # greeting
+          Next
+        Endif
+
+        End
         """.trimIndent()
     override fun getAdditionalHighlightingTagToDescriptorMap(): MutableMap<String, TextAttributesKey>? = null
 }

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/syntax/NOX3SyntaxHighlighter.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/syntax/NOX3SyntaxHighlighter.kt
@@ -12,41 +12,72 @@ import com.intellij.psi.TokenType
 import com.intellij.psi.tree.IElementType
 
 /**
- * Basic syntax highlighter for the X3 language. It recognises keywords,
- * literals and both line and block comments.
+ * Basic syntax highlighter for the Sage X3 language. It recognises keywords,
+ * literals, identifiers, operators and comments.
  */
 class NOX3SyntaxHighlighter : SyntaxHighlighterBase() {
+
     companion object {
-        val KEYWORD: TextAttributesKey = createTextAttributesKey("NOX3_KEYWORD", DefaultLanguageHighlighterColors.KEYWORD)
-        val IDENTIFIER: TextAttributesKey = createTextAttributesKey("NOX3_IDENTIFIER", DefaultLanguageHighlighterColors.IDENTIFIER)
-        val NUMBER: TextAttributesKey = createTextAttributesKey("NOX3_NUMBER", DefaultLanguageHighlighterColors.NUMBER)
-        val STRING: TextAttributesKey = createTextAttributesKey("NOX3_STRING", DefaultLanguageHighlighterColors.STRING)
-        val NUMBER: TextAttributesKey = createTextAttributesKey("NOX3_NUMBER", DefaultLanguageHighlighterColors.NUMBER)
-        val COMMENT: TextAttributesKey = createTextAttributesKey("NOX3_COMMENT", DefaultLanguageHighlighterColors.LINE_COMMENT)
-        val SEPARATOR: TextAttributesKey = createTextAttributesKey("NOX3_SEPARATOR", DefaultLanguageHighlighterColors.OPERATION_SIGN)
-        val BAD_CHARACTER: TextAttributesKey = createTextAttributesKey("NOX3_BAD_CHARACTER", HighlighterColors.BAD_CHARACTER)
-        val SEPARATOR: TextAttributesKey = createTextAttributesKey("NOX3_SEPARATOR", DefaultLanguageHighlighterColors.OPERATION_SIGN)
-        val IDENTIFIER: TextAttributesKey = createTextAttributesKey("NOX3_IDENTIFIER", DefaultLanguageHighlighterColors.IDENTIFIER)
+        val KEYWORD: TextAttributesKey =
+            createTextAttributesKey("NOX3_KEYWORD", DefaultLanguageHighlighterColors.KEYWORD)
 
+        val IDENTIFIER: TextAttributesKey =
+            createTextAttributesKey("NOX3_IDENTIFIER", DefaultLanguageHighlighterColors.IDENTIFIER)
 
-        private val ATTRIBUTES = mapOf<IElementType, TextAttributesKey>(
-            NOX3Types.MODULE to KEYWORD,
-            NOX3Types.FUNCTION to KEYWORD,
-            NOX3Types.VAR to KEYWORD,
-            NOX3Types.IF to KEYWORD,
-            NOX3Types.ENDIF to KEYWORD,
-            NOX3Types.FOR to KEYWORD,
-            NOX3Types.ENDFOR to KEYWORD,
-            NOX3Types.SEPARATOR to SEPARATOR,
-            NOX3Types.STRING to STRING,
-            NOX3Types.NUMBER to NUMBER,
-            NOX3Types.IDENTIFIER to IDENTIFIER,
-            NOX3Types.COMMENT to COMMENT,
-            TokenType.BAD_CHARACTER to BAD_CHARACTER
+        val NUMBER: TextAttributesKey =
+            createTextAttributesKey("NOX3_NUMBER", DefaultLanguageHighlighterColors.NUMBER)
+
+        val STRING: TextAttributesKey =
+            createTextAttributesKey("NOX3_STRING", DefaultLanguageHighlighterColors.STRING)
+
+        val COMMENT: TextAttributesKey =
+            createTextAttributesKey("NOX3_COMMENT", DefaultLanguageHighlighterColors.LINE_COMMENT)
+
+        val OPERATOR: TextAttributesKey =
+            createTextAttributesKey("NOX3_OPERATOR", DefaultLanguageHighlighterColors.OPERATION_SIGN)
+
+        val BAD_CHARACTER: TextAttributesKey =
+            createTextAttributesKey("NOX3_BAD_CHARACTER", HighlighterColors.BAD_CHARACTER)
+
+        private val KEYWORDS = setOf(
+            NOX3Types.SUBPROG,
+            NOX3Types.GLOBAL,
+            NOX3Types.LOCAL,
+            NOX3Types.CLASS,
+            NOX3Types.IF,
+            NOX3Types.THEN,
+            NOX3Types.ELSE,
+            NOX3Types.ENDIF,
+            NOX3Types.FOR,
+            NOX3Types.TO,
+            NOX3Types.NEXT
         )
+
+        private val OPERATORS = setOf(
+            NOX3Types.SEPARATOR, // '='
+            NOX3Types.PLUS,
+            NOX3Types.MINUS,
+            NOX3Types.LPAREN,
+            NOX3Types.RPAREN,
+            NOX3Types.COMMA,
+            NOX3Types.DOT,
+            NOX3Types.COLON
+        )
+
+        private val ATTRIBUTES: Map<IElementType, TextAttributesKey> = buildMap {
+            KEYWORDS.forEach { put(it, KEYWORD) }
+            OPERATORS.forEach { put(it, OPERATOR) }
+            put(NOX3Types.NUMBER, NUMBER)
+            put(NOX3Types.STRING, STRING)
+            put(NOX3Types.IDENTIFIER, IDENTIFIER)
+            put(NOX3Types.COMMENT, COMMENT)
+            put(TokenType.BAD_CHARACTER, BAD_CHARACTER)
+        }
     }
 
-    override fun getTokenHighlights(tokenType: IElementType): Array<TextAttributesKey> = pack(ATTRIBUTES[tokenType])
+    override fun getTokenHighlights(tokenType: IElementType): Array<TextAttributesKey> =
+        pack(ATTRIBUTES[tokenType])
 
     override fun getHighlightingLexer(): Lexer = NOX3LexerAdapter()
 }
+

--- a/src/test/kotlin/com/enterscript/nox3languageplugin/language/NOX3SyntaxHighlighterTest.kt
+++ b/src/test/kotlin/com/enterscript/nox3languageplugin/language/NOX3SyntaxHighlighterTest.kt
@@ -6,10 +6,10 @@ import kotlin.test.assertEquals
 
 class NOX3SyntaxHighlighterTest : BasePlatformTestCase() {
     fun testKeywordHighlighting() {
-        myFixture.configureByText("test.nox3", "module Demo")
+        myFixture.configureByText("test.nox3", "Subprog Demo")
         myFixture.checkHighlighting(false, true, false)
 
-        val highlight = myFixture.doHighlighting().first { it.startOffset == 0 && it.endOffset == "module".length }
+        val highlight = myFixture.doHighlighting().first { it.startOffset == 0 && it.endOffset == "Subprog".length }
         assertEquals(NOX3SyntaxHighlighter.KEYWORD, highlight.forcedTextAttributesKey)
     }
 }


### PR DESCRIPTION
## Summary
- map Sage X3 keywords, operators, literals and identifiers to dedicated highlighting keys
- hook highlighter up to NOX3LexerAdapter
- document all highlight types and provide demo snippet

## Testing
- `./gradlew test` *(fails: Unresolved reference: intellijPlatform)*
