### PR TITLE
chore(ci): set CodeQL to Java 17

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,10 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
       - uses: github/codeql-action/init@v3
         with: { languages: 'java' }  # ou kotlin/java, ajuste conforme o projeto
       - uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,5 +18,5 @@ jobs:
           distribution: zulu
           java-version: 17
       - uses: github/codeql-action/init@v3
-        with: { languages: 'java' }  # ou kotlin/java, ajuste conforme o projeto
+        with: { languages: 'kotlin' }  # ou kotlin/java, ajuste conforme o projeto
       - uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- add Java 17 setup to CodeQL workflow

## Testing
- `./gradlew test` *(fails: Unresolved reference: intellijPlatform)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bf9267708322bf8f2f0c17232158