### PR TITLE
Generate parser via GrammarKit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.grammarkit.tasks.GenerateLexer
-import org.jetbrains.grammarkit.tasks.GenerateParser
+import org.jetbrains.grammarkit.tasks.GenerateParserTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 fun properties(key: String) = project.findProperty(key).toString()
@@ -51,12 +51,11 @@ val generateNox3Lexer by tasks.registering(GenerateLexer::class) {
     purgeOldFiles.set(true)
 }
 
-val generateNox3Parser by tasks.registering(GenerateParser::class) {
-    source.set(file("src/main/grammars/NOX3.bnf"))
+tasks.register<GenerateParserTask>("generateNox3Parser") {
+    sourceFile.set(file("src/main/grammars/NOX3.bnf"))
     targetRoot.set(layout.buildDirectory.dir("gen"))
-    pathToParser.set("/com/enterscript/nox3languageplugin/language/parser/NOX3Parser.java")
-    pathToPsiRoot.set("/com/enterscript/nox3languageplugin/language/psi")
-    purgeOldFiles.set(true)
+    pathToParser.set("/com/enterscript/noX3LanguagePlugin/language/parser/NOX3Parser.java")
+    pathToPsiRoot.set("/com/enterscript/noX3LanguagePlugin/language/psi")
 }
 
 changelog {
@@ -115,5 +114,6 @@ tasks {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-    dependsOn(generateNox3Lexer, generateNox3Parser)
+    dependsOn(generateNox3Lexer)
+    dependsOn("generateNox3Parser")
 }

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/parser/NOX3ParserDefinition.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/parser/NOX3ParserDefinition.kt
@@ -3,11 +3,11 @@ package com.enterscript.nox3languageplugin.language.parser
 import com.enterscript.nox3languageplugin.language.NOX3Language
 import com.enterscript.nox3languageplugin.language.lexer.NOX3LexerAdapter
 import com.enterscript.nox3languageplugin.language.lexer._NOX3Lexer
-import com.enterscript.nox3languageplugin.language.parser.NOX3Parser
 import com.enterscript.nox3languageplugin.language.psi.NOX3File
 import com.enterscript.nox3languageplugin.language.psi.NOX3Types
 import com.intellij.lang.ASTNode
 import com.intellij.lang.ParserDefinition
+import com.intellij.lang.PsiParser
 import com.intellij.openapi.project.Project
 import com.intellij.psi.FileViewProvider
 import com.intellij.psi.PsiFile
@@ -29,6 +29,7 @@ class NOX3ParserDefinition : ParserDefinition {
     override fun getFileNodeType(): IFileElementType = FILE
     override fun createFile(viewProvider: FileViewProvider): PsiFile = NOX3File(viewProvider)
     override fun spaceExistanceTypeBetweenTokens(first: ASTNode, second: ASTNode) = ParserDefinition.SpaceRequirements.MAY
-    override fun createParser(project: Project) = NOX3Parser()
+    override fun createParser(project: Project): PsiParser =
+        com.enterscript.noX3LanguagePlugin.language.parser.NOX3Parser()
     override fun createElement(node: ASTNode) = NOX3Types.Factory.createElement(node)
 }


### PR DESCRIPTION
## Summary
- Add GrammarKit parser generation task and wire Kotlin compilation to invoke it
- Update NOX3ParserDefinition to reference the generated parser class

## Testing
- ⚠️ `./gradlew test` *(settings script references unresolved plugin and build failed)*
