### PR TITLE
chore: update IntelliJ platform plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,11 +8,11 @@ fun properties(key: String) = project.findProperty(key).toString()
 plugins {
     id("java")
     alias(libs.plugins.kotlin)
-    id("org.jetbrains.intellij.platform")
+    alias(libs.plugins.intellij.platform)
     alias(libs.plugins.changelog)
     alias(libs.plugins.qodana)
     alias(libs.plugins.kover)
-    id("org.jetbrains.grammarkit") version "2022.3.2.2"
+    alias(libs.plugins.grammarkit)
 }
 
 group = properties("pluginGroup")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ opentest4j = "1.3.0"
 
 # plugins
 changelog = "2.4.0"
-intelliJPlatform = "2.7.2"
+"intellij-platform" = "2.7.2"
 kotlin = "2.2.0"
 kover = "0.9.1"
 qodana = "2024.2.2"
@@ -17,7 +17,7 @@ opentest4j = { group = "org.opentest4j", name = "opentest4j", version.ref = "ope
 
 [plugins]
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }
-intelliJPlatform = { id = "org.jetbrains.intellij.platform", version.ref = "intelliJPlatform" }
+"intellij-platform" = { id = "org.jetbrains.intellij.platform", version.ref = "intellij-platform" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 qodana = { id = "org.jetbrains.qodana", version.ref = "qodana" }


### PR DESCRIPTION
## Summary
- switch to version catalog alias for org.jetbrains.intellij.platform
- reference grammarkit plugin via version catalog
- add intellij-platform plugin coordinates to version catalog

## Testing
- `./gradlew test` *(fails: Unresolved reference intellijPlatform in settings.gradle.kts)*
