### PR TITLE
Ensure Java 17 configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,14 @@ Thanks for your contributions!
 
 <!-- Plugin description end -->
 
+## Requirements
+
+This project requires **JDK 17**.
+
 ## Build
 
-This project requires **JDK 17**. The Gradle wrapper is configured for Gradle
-8.14 and will download it automatically. To compile and run the tests locally:
+The Gradle wrapper is configured for Gradle 8.14 and will download it
+automatically. To compile and run the tests locally:
 
 ```bash
 ./gradlew build

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.changelog.Changelog
 import org.jetbrains.grammarkit.tasks.GenerateLexer
 import org.jetbrains.grammarkit.tasks.GenerateParserTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.gradle.api.tasks.compile.JavaCompile
 
 fun properties(key: String) = project.findProperty(key).toString()
 
@@ -116,4 +117,9 @@ tasks {
 tasks.withType<KotlinCompile>().configureEach {
     dependsOn(generateNox3Lexer)
     dependsOn("generateNox3Parser")
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    sourceCompatibility = "17"
+    targetCompatibility = "17"
 }


### PR DESCRIPTION
## Summary
- configure Java compilation tasks to target JDK 17
- document JDK 17 requirement in the README

## Testing
- `./gradlew test` *(fails: Unresolved reference: intellijPlatform)*
