### PR TITLE
Use KEY tokens for completion

### DIFF
--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3CompletionContributor.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/NOX3CompletionContributor.kt
@@ -20,7 +20,7 @@ class NOX3CompletionContributor : CompletionContributor() {
         // Top level keywords and glossary terms
         extend(
             CompletionType.BASIC,
-            PlatformPatterns.psiElement(NOX3Types.IDENTIFIER)
+            PlatformPatterns.psiElement(NOX3Types.KEY)
                 .withLanguage(NOX3Language.INSTANCE)
                 .withSuperParent(2, PsiFile::class.java),
             object : CompletionProvider<CompletionParameters>() {
@@ -59,7 +59,7 @@ class NOX3CompletionContributor : CompletionContributor() {
         // Variables and properties from project stubs
         extend(
             CompletionType.BASIC,
-            PlatformPatterns.psiElement(NOX3Types.IDENTIFIER)
+            PlatformPatterns.psiElement(NOX3Types.KEY)
                 .withLanguage(NOX3Language.INSTANCE)
                 .andNot(
                     PlatformPatterns.psiElement()
@@ -94,7 +94,7 @@ class NOX3CompletionContributor : CompletionContributor() {
             KeywordStatus.Unknown to 5
         )
 
-        private val KEYWORDS = listOf("MODULE", "FUNCTION", "VAR", "IF", "ENDIF", "FOR", "ENDFOR")
+        private val KEYWORDS = listOf("KEY")
         private val SYMBOLS = listOf("=", "(", ")", ",")
 
         private fun iconFor(family: KeywordFamily): Icon = when (family) {

--- a/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/impl/NOX3PsiImplUtil.kt
+++ b/src/main/kotlin/com/enterscript/nox3languageplugin/language/psi/impl/NOX3PsiImplUtil.kt
@@ -8,13 +8,13 @@ import com.intellij.psi.PsiElement
 object NOX3PsiImplUtil {
     @JvmStatic
     fun getName(element: NOX3NamedElement): String? {
-        val idNode = element.node.findChildByType(NOX3Types.IDENTIFIER)
+        val idNode = element.node.findChildByType(NOX3Types.KEY)
         return idNode?.text
     }
 
     @JvmStatic
     fun setName(element: NOX3NamedElement, newName: String): PsiElement {
-        val idNode = element.node.findChildByType(NOX3Types.IDENTIFIER)
+        val idNode = element.node.findChildByType(NOX3Types.KEY)
         if (idNode != null) {
             val newId = NOX3ElementFactory.createIdentifier(element, newName)
             element.node.replaceChild(idNode, newId.node)
@@ -24,7 +24,7 @@ object NOX3PsiImplUtil {
 
     @JvmStatic
     fun getNameIdentifier(element: NOX3NamedElement): PsiElement? {
-        val idNode = element.node.findChildByType(NOX3Types.IDENTIFIER)
+        val idNode = element.node.findChildByType(NOX3Types.KEY)
         return idNode?.psi
     }
 


### PR DESCRIPTION
## Summary
- trigger code completion on KEY tokens instead of IDENTIFIER
- update keyword and symbol suggestions for KEY and SEPARATOR
- parse named elements using KEY tokens

## Testing
- ❌ `./gradlew build` (fails: Unresolved reference: intellijPlatform)
